### PR TITLE
fix (mifare, non-breaking): ReadNDEF should return all kinds of records present

### DIFF
--- a/mifare.go
+++ b/mifare.go
@@ -447,7 +447,7 @@ func (t *MIFARETag) ReadNDEF() (*NDEFMessage, error) {
 		}
 	}
 
-	return ParseNDEFData(data)
+	return ParseNDEFMessage(data)
 }
 
 func (t *MIFARETag) getTagCapacityParams() (maxSectors uint8, initialCapacity int) {


### PR DESCRIPTION
At the moment it attempts to parse the first text only record which will fail (no NDEF data) if the tag contains other kinds of records e.g. a URI exclusively