### PR TITLE
Add device path ignore functionality to DetectAll

### DIFF
--- a/detection/blocklist.go
+++ b/detection/blocklist.go
@@ -21,6 +21,7 @@
 package detection
 
 import (
+	"path/filepath"
 	"strings"
 )
 
@@ -124,4 +125,43 @@ func isHex(s string) bool {
 		}
 	}
 	return true
+}
+
+// IsPathIgnored checks if a device path should be ignored.
+// Supports exact path matching and normalized path comparison.
+func IsPathIgnored(devicePath string, ignorePaths []string) bool {
+	if devicePath == "" || len(ignorePaths) == 0 {
+		return false
+	}
+
+	// Normalize the device path for comparison
+	normalizedDevice := normalizedPath(devicePath)
+
+	for _, ignorePath := range ignorePaths {
+		if ignorePath == "" {
+			continue
+		}
+
+		normalizedIgnore := normalizedPath(ignorePath)
+
+		// Exact match
+		if normalizedDevice == normalizedIgnore {
+			return true
+		}
+
+		// Also check original paths for exact match
+		if devicePath == ignorePath {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizedPath normalizes a device path for comparison
+func normalizedPath(path string) string {
+	// Clean the path to resolve any relative components
+	cleaned := filepath.Clean(path)
+
+	// Convert to lowercase for case-insensitive comparison on Windows
+	return strings.ToLower(cleaned)
 }

--- a/detection/detector.go
+++ b/detection/detector.go
@@ -83,6 +83,8 @@ func (d DeviceInfo) String() string {
 type Options struct {
 	// USB VID:PID pairs to skip (e.g., ["1234:5678", "ABCD:EF01"])
 	Blocklist []string
+	// Device paths to explicitly ignore (e.g., ["/dev/ttyUSB0", "COM2"])
+	IgnorePaths []string
 	// Which transports to check (empty = all)
 	Transports []string
 	// Cache TTL duration

--- a/detection/i2c/detect_linux.go
+++ b/detection/i2c/detect_linux.go
@@ -84,6 +84,13 @@ func detectBusDevices(ctx context.Context, bus i2cBusInfo, opts *detection.Optio
 func createDeviceInfo(ctx context.Context, busPath string, addr uint8, opts *detection.Options) (
 	detection.DeviceInfo, bool,
 ) {
+	devicePath := fmt.Sprintf("%s:0x%02X", busPath, addr)
+
+	// Skip explicitly ignored device paths
+	if detection.IsPathIgnored(devicePath, opts.IgnorePaths) {
+		return detection.DeviceInfo{}, true
+	}
+
 	// Check if this could be a PN532
 	if addr != DefaultPN532Address && opts.Mode == detection.Passive {
 		// In passive mode, only consider default PN532 address
@@ -92,7 +99,7 @@ func createDeviceInfo(ctx context.Context, busPath string, addr uint8, opts *det
 
 	device := detection.DeviceInfo{
 		Transport: "i2c",
-		Path:      fmt.Sprintf("%s:0x%02X", busPath, addr),
+		Path:      devicePath,
 		Name:      fmt.Sprintf("I2C device at %s address 0x%02X", busPath, addr),
 		Metadata: map[string]string{
 			"bus":     busPath,

--- a/detection/ignore_paths_test.go
+++ b/detection/ignore_paths_test.go
@@ -1,0 +1,164 @@
+// go-pn532
+// Copyright (c) 2025 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+// This file is part of go-pn532.
+//
+// go-pn532 is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3 of the License, or (at your option) any later version.
+//
+// go-pn532 is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with go-pn532; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+package detection
+
+import (
+	"testing"
+)
+
+func TestIsPathIgnored(t *testing.T) {
+	t.Parallel()
+
+	tests := getPathIgnoredTests()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := IsPathIgnored(tt.devicePath, tt.ignorePaths)
+			if result != tt.expected {
+				t.Errorf("IsPathIgnored(%q, %v) = %v, want %v",
+					tt.devicePath, tt.ignorePaths, result, tt.expected)
+			}
+		})
+	}
+}
+
+type pathIgnoredTest struct {
+	name        string
+	devicePath  string
+	ignorePaths []string
+	expected    bool
+}
+
+//nolint:funlen // Test data function, acceptable to be longer
+func getPathIgnoredTests() []pathIgnoredTest {
+	basicTests := []pathIgnoredTest{
+		{
+			name:        "empty ignore list",
+			devicePath:  "/dev/ttyUSB0",
+			ignorePaths: []string{},
+			expected:    false,
+		},
+		{
+			name:        "empty device path",
+			devicePath:  "",
+			ignorePaths: []string{"/dev/ttyUSB0"},
+			expected:    false,
+		},
+		{
+			name:        "exact match unix path",
+			devicePath:  "/dev/ttyUSB0",
+			ignorePaths: []string{"/dev/ttyUSB0"},
+			expected:    true,
+		},
+		{
+			name:        "exact match windows path",
+			devicePath:  "COM2",
+			ignorePaths: []string{"COM2"},
+			expected:    true,
+		},
+	}
+
+	caseTests := []pathIgnoredTest{
+		{
+			name:        "case insensitive match",
+			devicePath:  "/dev/ttyUSB0",
+			ignorePaths: []string{"/DEV/TTYUSB0"},
+			expected:    true,
+		},
+		{
+			name:        "windows case insensitive",
+			devicePath:  "com2",
+			ignorePaths: []string{"COM2"},
+			expected:    true,
+		},
+	}
+
+	multipleTests := []pathIgnoredTest{
+		{
+			name:        "no match",
+			devicePath:  "/dev/ttyUSB1",
+			ignorePaths: []string{"/dev/ttyUSB0"},
+			expected:    false,
+		},
+		{
+			name:        "multiple paths with match",
+			devicePath:  "/dev/ttyUSB1",
+			ignorePaths: []string{"/dev/ttyUSB0", "/dev/ttyUSB1", "COM2"},
+			expected:    true,
+		},
+		{
+			name:        "multiple paths no match",
+			devicePath:  "/dev/ttyUSB2",
+			ignorePaths: []string{"/dev/ttyUSB0", "/dev/ttyUSB1", "COM2"},
+			expected:    false,
+		},
+	}
+
+	specialTests := []pathIgnoredTest{
+		{
+			name:        "i2c path format",
+			devicePath:  "/dev/i2c-1:0x24",
+			ignorePaths: []string{"/dev/i2c-1:0x24"},
+			expected:    true,
+		},
+		{
+			name:        "spi path format",
+			devicePath:  "/dev/spidev0.0",
+			ignorePaths: []string{"/dev/spidev0.0"},
+			expected:    true,
+		},
+		{
+			name:        "path with relative components",
+			devicePath:  "/dev/../dev/ttyUSB0",
+			ignorePaths: []string{"/dev/ttyUSB0"},
+			expected:    true,
+		},
+		{
+			name:        "empty strings in ignore list",
+			devicePath:  "/dev/ttyUSB0",
+			ignorePaths: []string{"", "/dev/ttyUSB0", ""},
+			expected:    true,
+		},
+	}
+
+	result := make([]pathIgnoredTest, 0, len(basicTests)+len(caseTests)+len(multipleTests)+len(specialTests))
+	result = append(result, basicTests...)
+	result = append(result, caseTests...)
+	result = append(result, multipleTests...)
+	result = append(result, specialTests...)
+	return result
+}
+
+func TestOptionsWithIgnorePaths(t *testing.T) {
+	t.Parallel()
+
+	opts := DefaultOptions()
+	if opts.IgnorePaths != nil {
+		t.Errorf("DefaultOptions().IgnorePaths should be nil, got %v", opts.IgnorePaths)
+	}
+
+	// Test that we can set ignore paths
+	opts.IgnorePaths = []string{"/dev/ttyUSB0", "COM2"}
+	if len(opts.IgnorePaths) != 2 {
+		t.Errorf("Expected 2 ignore paths, got %d", len(opts.IgnorePaths))
+	}
+}

--- a/detection/spi/detector.go
+++ b/detection/spi/detector.go
@@ -159,6 +159,11 @@ func (*detector) Detect(ctx context.Context, opts *detection.Options) ([]detecti
 		default:
 		}
 
+		// Skip explicitly ignored device paths
+		if detection.IsPathIgnored(config.Device, opts.IgnorePaths) {
+			continue
+		}
+
 		device := createDeviceInfo(config)
 
 		if probeAndUpdateDevice(ctx, config, &device, opts) {

--- a/detection/uart/detector.go
+++ b/detection/uart/detector.go
@@ -89,6 +89,11 @@ func (d *detector) filterPorts(ports []serialPort, opts *detection.Options) []se
 			continue
 		}
 
+		// Skip explicitly ignored device paths
+		if detection.IsPathIgnored(port.Path, opts.IgnorePaths) {
+			continue
+		}
+
 		// Copy the loop variable to avoid memory aliasing
 		portCopy := port
 		// Apply platform-specific positive filtering


### PR DESCRIPTION
## Summary
Adds the ability to specify device paths that should be explicitly ignored during PN532 detection, preventing aggressive probing of sensitive devices.

## Changes
- ✅ Add `IgnorePaths` field to `detection.Options` struct
- ✅ Implement `IsPathIgnored()` function with case-insensitive path matching
- ✅ Update UART detector to respect ignore list
- ✅ Update I2C detector to respect ignore list  
- ✅ Update SPI detector to respect ignore list
- ✅ Add comprehensive tests covering edge cases
- ✅ Support Unix paths (`/dev/ttyUSB0`), Windows paths (`COM2`), and transport-specific formats

## Usage Example
```go
opts := detection.DefaultOptions()
opts.IgnorePaths = []string{
    "/dev/ttyUSB0",    // Ignore specific serial port
    "COM2",            // Ignore Windows COM port
    "/dev/i2c-1:0x24", // Ignore I2C device
}

devices, err := detection.DetectAll(&opts)
```

## Key Features
- **Early filtering**: Paths checked before any communication attempts
- **Cross-transport**: Works with UART, I2C, and SPI detection
- **Case-insensitive**: Handles Windows COM port variations
- **Path normalization**: Resolves relative path components
- **Zero overhead**: No performance impact for non-ignored devices

## Test Coverage
- [x] Empty ignore lists and device paths
- [x] Exact path matching (Unix and Windows)
- [x] Case-insensitive matching
- [x] Multiple path scenarios
- [x] Transport-specific path formats
- [x] Path normalization with relative components
- [x] Edge cases (empty strings, mixed lists)

Fixes the issue where DetectAll could be too aggressive even with existing safety levels.