### PR TITLE
feat: add mifare extra utils

### DIFF
--- a/mifare_extra.go
+++ b/mifare_extra.go
@@ -1,0 +1,9 @@
+package pn532
+
+// IsNDEFFormatted checks if the tag is NDEF formatted with the default NDEF KeyA
+func (t *MIFARETag) IsNDEFFormatted() bool {
+	ndefKeyBytes := t.ndefKey.bytes()
+	defer clear(ndefKeyBytes)
+
+	return t.Authenticate(1, MIFAREKeyA, ndefKeyBytes) == nil
+}


### PR DESCRIPTION
I'm adding this as extra utils because some may be redundant. If they are useful enough, they could go into mifare.go.

### 1. Added a fast check if a tag is NDEF compatible formatted

 Optional method to check if a tag is NDEF formatted before attempting a ReadNDEF.

Typically, attempting to read a factory formatted/blank card takes 550ms on DefaultRetryConfig before an error is returned: `Failed to read NDEF data: failed to read NDEF data: tag may not be NDEF formatted: robust authentication failed after all attempts: authentication failed after 3 attempts: authentication failed: data exchange error: 14`.

This method takes about 60ms to check if a tag is potentially NDEF formatted with the default key. Since we are dealing with sector 1 here, I think we can avoid using AuthenticateRobust and save even more time.

* https://stackoverflow.com/a/56226964/6004371