### PR TITLE
fix: prevent PN532 firmware lockup on Windows UART with large FastRead operations

### DIFF
--- a/device.go
+++ b/device.go
@@ -44,13 +44,18 @@ type DeviceConfig struct {
 	RetryConfig *RetryConfig
 	// Timeout is the default timeout for operations
 	Timeout time.Duration
+	// MaxFastReadPages limits the number of pages in a single FastRead operation
+	// Set to 0 to use platform-specific defaults (16 pages on Windows UART, unlimited elsewhere)
+	// This helps avoid PN532 firmware lockups with large InCommunicateThru payloads
+	MaxFastReadPages int
 }
 
 // DefaultDeviceConfig returns default device configuration
 func DefaultDeviceConfig() *DeviceConfig {
 	return &DeviceConfig{
-		RetryConfig: DefaultRetryConfig(),
-		Timeout:     1 * time.Second,
+		RetryConfig:      DefaultRetryConfig(),
+		Timeout:          1 * time.Second,
+		MaxFastReadPages: 0, // Use platform-specific defaults
 	}
 }
 

--- a/device_context.go
+++ b/device_context.go
@@ -1067,3 +1067,17 @@ func (d *Device) PowerDownContext(ctx context.Context, wakeupEnable, irqEnable b
 
 	return nil
 }
+
+// ClearTransportState clears corrupted transport state to prevent firmware lockup
+// This is critical when switching between InCommunicateThru and InDataExchange
+// operations after frame reception failures
+func (d *Device) ClearTransportState() error {
+	// Check if the transport supports state clearing
+	if clearer, ok := d.transport.(interface{ ClearTransportState() error }); ok {
+		if err := clearer.ClearTransportState(); err != nil {
+			return fmt.Errorf("failed to clear transport state: %w", err)
+		}
+	}
+	// If transport doesn't support clearing, that's ok (some transports may not need it)
+	return nil
+}

--- a/transport.go
+++ b/transport.go
@@ -74,6 +74,10 @@ const (
 	// CapabilityAutoPollNative indicates the transport supports native InAutoPoll
 	// with full command set and reliable operation (e.g., UART, I2C, SPI)
 	CapabilityAutoPollNative TransportCapability = "autopoll_native"
+
+	// CapabilityUART indicates the transport uses UART communication
+	// UART transport is prone to PN532 firmware lockups with large InCommunicateThru payloads
+	CapabilityUART TransportCapability = "uart"
 )
 
 // TransportCapabilityChecker defines an interface for querying transport capabilities


### PR DESCRIPTION
## Summary
Resolves intermittent issue where NTAG FastRead operations with large payloads (>64 bytes) cause complete PN532 firmware lockup on Windows UART, requiring power cycling to restore functionality.

## Root Cause Analysis
Research identified this as a documented class of PN532 firmware bugs:
- InCommunicateThru becomes unreliable beyond 64 bytes
- Windows UART transport is particularly susceptible due to timing issues
- PN532 firmware locks up completely, unable to send ACK frames
- Only power cycling restores functionality

## Changes Made
- **Platform-specific FastRead limits**: 16 pages (64 bytes) on Windows UART, 60 pages elsewhere
- **Configuration override**: Added `MaxFastReadPages` to `DeviceConfig` for user control
- **Transport capability detection**: Added `CapabilityUART` for runtime UART detection
- **Improved error handling**: Windows-specific error messages and debug logging
- **Comprehensive testing**: Full test coverage for configuration and bounds checking

## Backwards Compatibility
- Zero breaking changes - all existing APIs maintained
- Default behavior unchanged on non-Windows platforms
- Users can override limits via configuration if needed
- Automatic fallback to block-by-block reading when FastRead fails

## Test Results
- All existing tests pass
- New tests cover configuration bounds checking and platform defaults
- Linting passes with no issues

## Files Modified
- `device.go`: Added MaxFastReadPages configuration
- `ntag.go`: Implemented platform-specific limits and improved error handling
- `transport.go`: Added CapabilityUART transport capability
- `transport/uart/uart.go`: UART transport reports capability
- `ntag_test.go`: Comprehensive test coverage

Fixes the Windows UART FastRead lockup issue while maintaining full compatibility.