### PR TITLE
fix(polling): remove InRelease calls that block tag removal detection

### DIFF
--- a/polling/session.go
+++ b/polling/session.go
@@ -511,9 +511,6 @@ func (s *Session) handlePollingError(err error) {
 		return
 	}
 
-	// Release targets to reset PN532 state machine after errors
-	_ = s.device.InRelease(context.Background(), 0)
-
 	// For serious device errors, trigger immediate card removal
 	// This handles cases like device disconnection
 	s.handleCardRemoval()
@@ -533,11 +530,6 @@ func (s *Session) handleCardRemoval() {
 	}
 	onRemoved := s.OnCardRemoved
 	s.stateMutex.Unlock()
-
-	// Release targets to reset PN532 state machine after card removal
-	if wasPresent {
-		_ = s.device.InRelease(context.Background(), 0)
-	}
 
 	// Call callback outside the lock to avoid potential deadlocks
 	if wasPresent && onRemoved != nil {

--- a/polling/session_test.go
+++ b/polling/session_test.go
@@ -1208,18 +1208,15 @@ func TestSession_HandlePollingError(t *testing.T) {
 		session.handlePollingError(context.Canceled)
 	})
 
-	t.Run("HandlesOtherErrors_CallsInRelease", func(t *testing.T) {
+	t.Run("HandlesOtherErrors_TriggersCardRemoval", func(t *testing.T) {
 		t.Parallel()
-		device, mockTransport := createMockDeviceWithTransport(t)
+		device, _ := createMockDeviceWithTransport(t)
 		session := NewSession(device, nil)
 
-		// Set up InRelease response
-		mockTransport.SetResponse(0x52, []byte{0x53, 0x00}) // InRelease response
-
-		// Should call InRelease and handleCardRemoval
+		// Should trigger handleCardRemoval for transport errors
 		session.handlePollingError(errors.New("some transport error"))
 
-		// No panic means success - InRelease was called
+		// No panic means success
 	})
 }
 
@@ -1241,18 +1238,15 @@ func TestSession_HandleCardRemoval(t *testing.T) {
 		device, _ := createMockDeviceWithTransport(t)
 		session := NewSession(device, nil)
 
-		// Card not present, should not call InRelease or callback
+		// Card not present, should not call callback
 		session.handleCardRemoval()
 		assert.False(t, session.state.Present)
 	})
 
-	t.Run("CallsInReleaseAndCallback_WhenCardWasPresent", func(t *testing.T) {
+	t.Run("CallsCallback_WhenCardWasPresent", func(t *testing.T) {
 		t.Parallel()
-		device, mockTransport := createMockDeviceWithTransport(t)
+		device, _ := createMockDeviceWithTransport(t)
 		session := NewSession(device, nil)
-
-		// Set up InRelease response
-		mockTransport.SetResponse(0x52, []byte{0x53, 0x00}) // InRelease response
 
 		// Simulate card was present
 		session.stateMutex.Lock()


### PR DESCRIPTION
## Summary

- Remove `InRelease` calls from `handleCardRemoval()` and `handlePollingError()` that were blocking tag removal detection for up to 4.8 seconds
- Update tests to reflect the removal of `InRelease` calls

## Problem

Tag removal events were taking ~5 seconds to fire instead of being near-immediate. This regression was introduced in v0.10.2 when `InRelease` calls were added to `handleCardRemoval()` and `handlePollingError()`.

**Root cause:** When the 600ms removal timer fires and calls `handleCardRemoval()`, it tried to send `InRelease` to the PN532. But the PN532 was still busy executing `InListPassiveTarget` for up to 4.8 seconds (due to `HardwareTimeoutRetries: 0x20`). The `InRelease` call blocked waiting for the device, preventing the `onRemoved()` callback from firing.

## Why InRelease is NOT appropriate here

Per PN532 datasheet:
- `InRelease` means "the host controller has finished communication with the target(s)"
- It sends HLTA to put the tag in HALT state
- "If there is no more activated target after the release...the PN532 automatically returns in Standby mode, meaning the RF field is switched off"

Per libnfc reference implementation:
- `InRelease` is ONLY used in `pn53x_idle()` when **completely done** with NFC operations
- It's for shutting down, not for continuous polling

For continuous polling:
1. We're NOT done with NFC - we want to continue polling for new tags
2. Calling `InRelease` may turn off the RF field (counterproductive)
3. The tag removal is already detected via the timer mechanism
4. Calling `InRelease` while `InListPassiveTarget` is running blocks until it completes

## Expected behavior after fix

- Tag removal detected within ~600ms (the `CardRemovalTimeout`)
- After NDEF read: ~300ms (uses `timeout/2` in `StatePostReadGrace`)
- LED blinking behavior unchanged (still reduced due to HardwareTimeoutRetries)
- RF field stays on for continuous polling

## Test plan

- [x] All existing tests pass
- [ ] Manual test: tag removal should be detected within ~600ms