### PR TITLE
fix(i2c): increase jittery test timeout on Windows

### DIFF
--- a/transport/i2c/i2c_wire_test.go
+++ b/transport/i2c/i2c_wire_test.go
@@ -4,6 +4,7 @@ package i2c
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -499,10 +500,15 @@ var _ i2c.Bus = (*JitteryMockI2CBus)(nil)
 func newJitteryTestI2CTransport(sim *virt.VirtualPN532, config virt.JitterConfig) *Transport {
 	mockBus := NewJitteryMockI2CBus(sim, config)
 	dev := &i2c.Dev{Addr: pn532WriteAddr, Bus: mockBus}
+	// Use longer timeout on Windows due to less predictable goroutine scheduling
+	timeout := 500 * time.Millisecond
+	if runtime.GOOS == "windows" {
+		timeout = 1500 * time.Millisecond
+	}
 	return &Transport{
 		dev:     dev,
 		busName: "mock://jittery-i2c",
-		timeout: 500 * time.Millisecond,
+		timeout: timeout,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Increase I2C jittery test timeout from 500ms to 1500ms on Windows
- Matches the UART transport's Windows timeout adjustment pattern

## Problem

The I2C jittery tests (`TestI2C_Jittery_MultipleCommands`, `TestI2C_Jittery_USBBoundaryStress`) were failing on Windows CI with transport timeouts. Windows has less predictable goroutine scheduling which makes the 500ms timeout too tight when combined with simulated jitter.

## Test plan

- [x] All I2C jittery tests pass locally
- [x] `make check` passes
- [ ] Windows CI passes