### PR TITLE
fix: exit polling loops on fatal I/O errors

### DIFF
--- a/polling/session.go
+++ b/polling/session.go
@@ -428,8 +428,11 @@ func (s *Session) executeSinglePollingCycle(ctx context.Context) error {
 	if err != nil {
 		if !errors.Is(err, ErrNoTagInPoll) {
 			s.handlePollingError(err)
+			if pn532.IsFatal(err) {
+				return err // Fatal error - exit polling loop
+			}
 		}
-		return nil
+		return nil // Transient error or no tag - continue polling
 	}
 
 	if err := s.processPollingResults(detectedTag); err != nil {


### PR DESCRIPTION
## Summary

- Add `IsFatal(err)` function to identify device-level failures (transport closed, device not found, `io.EOF`, etc.)
- `Session.executeSinglePollingCycle` now returns fatal errors to exit the polling loop
- `DeviceActor` adds `OnFatalError` callback and auto-stops on fatal errors

## Problem

When a PN532 device is unplugged during polling, `Session.Start()` blocks forever because both polling implementations swallowed fatal I/O errors instead of propagating them.

## Solution

Created a new `IsFatal(err)` function distinct from `IsRetryable(err)`:
- **Retryable errors** (timeouts, frame corruption) → continue polling
- **Fatal errors** (transport closed, device gone) → exit polling loop

## Test plan

- [x] `TestIsFatal` and `TestIsFatal_TransportError` verify error classification
- [x] `TestSession_ExecuteSinglePollingCycle_FatalError` verifies session exits on fatal errors
- [x] `TestDeviceActor_FatalError_*` tests verify callback and auto-stop behavior
- [x] All existing tests pass
- [x] Linting passes