### PR TITLE
Cache CC bytes and fix target selection after SendRawCommand

### DIFF
--- a/tagops/tagops.go
+++ b/tagops/tagops.go
@@ -180,6 +180,15 @@ func (t *TagOperations) GetUID() []byte {
 	return t.tag.UIDBytes
 }
 
+// GetCachedCapabilityContainer returns the CC bytes cached during NTAG detection.
+// Returns nil if the tag is not an NTAG or if DetectType has not been called.
+func (t *TagOperations) GetCachedCapabilityContainer() []byte {
+	if t.ntagInstance == nil {
+		return nil
+	}
+	return t.ntagInstance.GetCachedCapabilityContainer()
+}
+
 // detectAndInitializeTag determines the tag type and sets up the appropriate handler
 func (t *TagOperations) detectAndInitializeTag(ctx context.Context) error {
 	if t.tag == nil {


### PR DESCRIPTION
## Summary

- **Feature**: Cache Capability Container bytes during NTAG detection for Amiibo/LEGO Dimensions identification
- **Bug fix**: Always call InSelect after SendRawCommand to fix ReadBlock failures after DetectType

## Changes

### Part 1: Cache CC Bytes
- Add `capabilityContainer` field to `NTAGTag` struct
- Cache CC in `DetectType()` after reading page 3
- Add `GetCachedCapabilityContainer()` method to `NTAGTag` and `TagOperations`
- Returns defensive copy to prevent modification of internal state

### Part 2: Fix Target Selection Recovery
- Move `InSelect` outside success-only block in `readBlockCommunicateThru`
- Add `InSelect` before fallback retry in `readBlockDirectFallback`

## Root Cause

`SendRawCommand` uses `InCommunicateThru` (0x42) which doesn't maintain the PN532's target selection state. Previously, `InSelect` was only called on success paths, leaving the target unselected on error paths. Subsequent `InDataExchange` calls would then fail with timeout error 0x01.

## Test plan

- [x] `make check` passes (lint + test + deadlock)
- [x] New tests for CC caching (returns nil before DetectType, returns cached CC after, returns copy not reference)
- [x] Existing test `TestNTAG_GetVersionDoesNotBreakSubsequentReads` validates target selection fix