### PR TITLE
ci: add SBOM generation and artifact attestations to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -60,7 +60,13 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
     - name: Download all artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       with:
@@ -70,8 +76,27 @@ jobs:
     - name: List artifacts
       run: find artifacts -type f
 
+    - name: Generate SBOM
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+      with:
+        format: spdx-json
+        output-file: artifacts/sbom.spdx.json
+
+    - name: Attest build provenance
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+      with:
+        subject-path: 'artifacts/*.zip'
+
+    - name: Attest SBOM
+      uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+      with:
+        subject-path: 'artifacts/*.zip'
+        sbom-path: artifacts/sbom.spdx.json
+
     - name: Create Release
       uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
       with:
-        files: artifacts/**/*.zip
+        files: |
+          artifacts/*.zip
+          artifacts/sbom.spdx.json
         generate_release_notes: true


### PR DESCRIPTION
## Summary

- Add Sigstore-signed build provenance attestations to release artifacts
- Generate SPDX SBOM and attach as both an attestation and a release asset
- Narrow workflow-level permissions to `contents: read`, widen at job level where needed
- Release artifacts verifiable with `gh attestation verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow security and supply chain integrity measures, including automated artifact verification and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->