### PR TITLE
fix(ndef): stop parsing at ME flag to tolerate trailing data

### DIFF
--- a/ndef_test.go
+++ b/ndef_test.go
@@ -246,6 +246,22 @@ func TestParseNDEFMessage(t *testing.T) {
 			expectError:   false,
 			expectedCount: 0, // Empty NDEF = no records
 		},
+		{
+			// Regression for issue #51: tags written by other NFC tools or with
+			// leftover data from prior writes commonly have padding past ME.
+			// The parser must stop at ME and return the single valid record.
+			name: "Trailing_Padding_After_ME",
+			setupData: func() []byte {
+				return []byte{
+					0x03, 0x07,
+					0xD1, 0x01, 0x01, 0x54, 0x02,
+					0x00, 0x00,
+					0xFE,
+				}
+			},
+			expectError:   false,
+			expectedCount: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/ndef_validation.go
+++ b/ndef_validation.go
@@ -229,6 +229,14 @@ func validateNDEFStructure(data []byte) error {
 
 		recordCount++
 		pos += consumed
+
+		// Stop at ME flag. Any trailing bytes inside the TLV length window are
+		// padding or leftover data from prior writes by other NFC tools, and
+		// real-world tags commonly have this pattern. The NFC Forum spec treats
+		// ME as the logical end of the message regardless of remaining bytes.
+		if state.lastRecordSeen {
+			break
+		}
 	}
 
 	return validateMessageCompleteness(state)

--- a/ndef_validation_test.go
+++ b/ndef_validation_test.go
@@ -51,6 +51,42 @@ func TestValidateNDEFMessage(t *testing.T) {
 			data:    []byte{0x03, 0x10, 0x01, 0x02}, // Claims 16 bytes but only 2 provided
 			wantErr: true,
 		},
+		{
+			// Regression for issue #51: real-world tags have leftover bytes from
+			// prior writes past the ME record. TLV length says 7, single record
+			// consumes 5, remaining 2 bytes are zero padding.
+			name:    "trailing zero padding after ME",
+			data:    []byte{0x03, 0x07, 0xD1, 0x01, 0x01, 0x54, 0x02, 0x00, 0x00, 0xFE},
+			wantErr: false,
+		},
+		{
+			// Regression for issue #51: same shape as above but with non-zero
+			// trailing bytes (garbage from a prior tool write).
+			name:    "trailing garbage after ME",
+			data:    []byte{0x03, 0x07, 0xD1, 0x01, 0x01, 0x54, 0x02, 0xAA, 0xBB, 0xFE},
+			wantErr: false,
+		},
+		{
+			// Regression for issue #51: two consecutive records where the first
+			// already has ME set. The second is trailing data and must be ignored.
+			// First record (5 bytes): MB|ME|SR|TNF(1) type len 1 payload len 1 'T' 0x02
+			// Trailing 5 bytes interpreted as another record would fail without the fix.
+			name: "second record after ME is ignored",
+			data: []byte{
+				0x03, 0x0A,
+				0xD1, 0x01, 0x01, 0x54, 0x02,
+				0x51, 0x01, 0x01, 0x54, 0x03,
+			},
+			wantErr: false,
+		},
+		{
+			// Regression guard: a record with MB set but no ME must still error
+			// after the loop exits (validateMessageCompleteness rejects it).
+			// 0x91 = MB|SR|TNF(1), no ME.
+			name:    "record with MB but no ME is still rejected",
+			data:    []byte{0x03, 0x05, 0x91, 0x01, 0x01, 0x54, 0x02},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- NDEF parser's `validateNDEFStructure` looped over the entire TLV-length window and rejected any bytes that followed a record with the ME (Message End) flag, producing `invalid NDEF message: record 1: invalid MB/ME flags: record after ME flag`.
- Real-world tags written by other NFC tools or previously holding longer messages commonly have padding/leftover bytes past ME. The NFC Forum spec treats ME as the logical end of the message regardless of remaining bytes.
- Fix: break out of the validation loop as soon as a record with ME is processed. The lower-level `pkg/ndef` `Message.Unmarshal` already stops at ME, so validation was the only rejecting layer. Tags without any ME flag are still rejected by `validateMessageCompleteness`.

Fixes #51 (13 Sentry occurrences on MiSTer/arm, tags were falling back to UID-only mode instead of reading NDEF text content).

## Test plan

- [x] `make test` — full suite passes with race detection
- [x] `make lint` — 0 issues
- [x] New table entries in `TestValidateNDEFMessage`:
  - trailing zero padding after ME → accepted
  - trailing garbage after ME → accepted
  - second record after ME is ignored → accepted
  - record with MB but no ME is still rejected (regression guard)
- [x] New entry in `TestParseNDEFMessage` (`Trailing_Padding_After_ME`) verifies end-to-end round-trip returns the single valid record

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the NDEF parser to correctly handle trailing data and padding bytes that appear after a message termination marker. The parser now properly stops at the termination point and ignores remaining bytes, preventing parsing errors on certain valid input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->