### PR TITLE
fix(polling): harden Start-path against goroutine leaks

### DIFF
--- a/polling/recovery.go
+++ b/polling/recovery.go
@@ -80,10 +80,12 @@ func (r *DefaultRecoverer) AttemptRecovery(ctx context.Context) error {
 
 	for attempt := range r.maxAttempts {
 		if attempt > 0 {
+			timer := time.NewTimer(r.backoff)
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				return ctx.Err()
-			case <-time.After(r.backoff):
+			case <-timer.C:
 			}
 		}
 

--- a/polling/session.go
+++ b/polling/session.go
@@ -89,7 +89,17 @@ func NewSession(device *pn532.Device, config *Config) *Session {
 	return session
 }
 
-// Start begins continuous monitoring for cards
+// Start begins continuous monitoring for cards. It blocks until ctx is cancelled
+// or an unrecoverable error occurs.
+//
+// Callers must:
+//  1. Run Start in a dedicated goroutine.
+//  2. Track that goroutine (for example with a sync.WaitGroup).
+//  3. On shutdown, cancel the context, call Close, then wait for the goroutine.
+//
+// Start returns promptly when ctx is cancelled during normal polling. During the
+// initial hardware configuration it is bounded by startInitTimeout so a wedged
+// transport cannot delay Start's exit indefinitely.
 func (s *Session) Start(ctx context.Context) error {
 	return s.continuousPolling(ctx)
 }
@@ -236,12 +246,16 @@ func (s *Session) pauseWithAck(ctx context.Context) error {
 	// Send pause signal with context-aware non-blocking send
 	select {
 	case s.pauseChan <- struct{}{}:
-		// Successfully sent pause signal, now wait for acknowledgment with timeout
+		// Successfully sent pause signal, now wait for acknowledgment with timeout.
+		// Use a named timer so cancellation releases the underlying runtime timer
+		// immediately rather than lingering until it fires.
+		ackTimer := time.NewTimer(100 * time.Millisecond)
+		defer ackTimer.Stop()
 		select {
 		case <-s.ackChan:
 			// Polling goroutine has acknowledged the pause
 			return nil
-		case <-time.After(100 * time.Millisecond):
+		case <-ackTimer.C:
 			// No acknowledgment received - likely no polling loop running
 			// This is OK for testing scenarios, pause state is already set
 			return nil
@@ -273,10 +287,12 @@ func (s *Session) executeWriteToTag(
 	// This prevents error 0x27 ("wrong context") which occurs when the user is
 	// still positioning the card as the write triggers. The RF field becomes
 	// unstable during movement, causing the PN532 to lose target selection.
+	stabilizationTimer := time.NewTimer(writeStabilizationDelay)
 	select {
 	case <-writeCtx.Done():
+		stabilizationTimer.Stop()
 		return writeCtx.Err()
-	case <-time.After(writeStabilizationDelay):
+	case <-stabilizationTimer.C:
 	}
 
 	// Use GetDevice() to get the current device reference (may be updated after recovery)
@@ -417,19 +433,40 @@ func (s *Session) continuousPolling(ctx context.Context) error {
 	return s.runPollingLoop(ctx, s.executeSinglePollingCycle)
 }
 
-// runPollingLoop is the generic polling loop used by both single and multi-tag modes
-func (s *Session) runPollingLoop(ctx context.Context, cycleFunc func(context.Context) error) error {
-	// Configure PN532 hardware polling retries to reduce host-side polling frequency
-	// This tells the PN532 to retry detection internally before returning to the host
-	if err := s.device.SetPollingRetries(ctx, s.config.HardwareTimeoutRetries); err != nil {
+// startInitTimeout caps how long Session.Start will spend configuring the
+// PN532 before the polling loop begins. A wedged transport must not block
+// Start's goroutine past this bound.
+const startInitTimeout = 5 * time.Second
+
+// configureInitialHardware runs the one-time hardware setup that Start performs
+// before entering the polling loop. Both commands are bounded by startInitTimeout
+// so cancellation during Start's first two I/O calls is observed promptly even
+// if the transport is unresponsive.
+func (s *Session) configureInitialHardware(ctx context.Context) error {
+	initCtx, cancel := context.WithTimeout(ctx, startInitTimeout)
+	defer cancel()
+
+	if err := s.device.SetPollingRetries(initCtx, s.config.HardwareTimeoutRetries); err != nil {
 		return fmt.Errorf("failed to configure hardware polling retries: %w", err)
 	}
 
-	// Set device timeout to match hardware retries plus buffer
-	// Each retry is ~150ms, plus 1s buffer for host/driver overhead
+	// Set device timeout to match hardware retries plus buffer.
+	// Each retry is ~150ms, plus 1s buffer for host/driver overhead.
 	hwTimeout := time.Duration(s.config.HardwareTimeoutRetries)*150*time.Millisecond + time.Second
 	if err := s.device.SetTimeout(hwTimeout); err != nil {
 		return fmt.Errorf("failed to set device timeout: %w", err)
+	}
+	return nil
+}
+
+// runPollingLoop is the generic polling loop used by both single and multi-tag modes
+func (s *Session) runPollingLoop(ctx context.Context, cycleFunc func(context.Context) error) error {
+	// Bound the initial hardware configuration with a per-start timeout so a
+	// sluggish or unresponsive transport cannot delay Start's exit indefinitely.
+	// This keeps the goroutine that runs Start honest about cancellation even
+	// when the hardware is wedged on its first command.
+	if err := s.configureInitialHardware(ctx); err != nil {
+		return err
 	}
 
 	ticker := time.NewTicker(s.config.PollInterval)

--- a/polling/session_test.go
+++ b/polling/session_test.go
@@ -18,6 +18,7 @@ package polling
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2131,3 +2132,104 @@ func (m *minimalMockTransport) IsConnected() bool {
 }
 
 func (*minimalMockTransport) Type() pn532.TransportType { return pn532.TransportMock }
+
+// --- Issue #50 regression tests: Start-path cancellation and goroutine leaks ---
+
+// TestSession_Start_NoLeakOnFailedInit runs many Start/Close cycles against a
+// mock transport that fails RFConfiguration (the first command Start issues via
+// SetPollingRetries). Each Start must return promptly, and the total goroutine
+// count must not grow unbounded across cycles.
+//
+// This guards against the regression reported in issue #50 where repeated
+// reconnects after SAM configuration failures accumulated thousands of
+// goroutines on MiSTer devices.
+//
+// The test deliberately does not use t.Parallel() because parallel test
+// goroutines would pollute the NumGoroutine counts.
+//
+//nolint:paralleltest // intentional: measures goroutine count, must run serially
+func TestSession_Start_NoLeakOnFailedInit(t *testing.T) {
+	// Allow the runtime to settle any background goroutines before snapshotting.
+	runtime.GC() //nolint:revive // explicit GC stabilises NumGoroutine baseline
+	time.Sleep(20 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	const cycles = 50
+	for i := range cycles {
+		device, mockTransport := createMockDeviceWithTransport(t)
+		// Fail the very first command Start issues via SetPollingRetries.
+		mockTransport.SetError(0x32, errors.New("simulated RFConfiguration failure"))
+
+		session := NewSession(device, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- session.Start(ctx)
+		}()
+
+		select {
+		case err := <-errCh:
+			require.Errorf(t, err, "cycle %d: Start should fail when RFConfiguration errors", i)
+		case <-time.After(2 * time.Second):
+			cancel()
+			t.Fatalf("cycle %d: Start did not return within 2s", i)
+		}
+		cancel()
+		require.NoError(t, session.Close())
+	}
+
+	// Allow any leftover timer goroutines to drain before counting.
+	runtime.GC() //nolint:revive // explicit GC releases lingering timer goroutines
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC() //nolint:revive // second GC catches finalised timer heap entries
+
+	delta := runtime.NumGoroutine() - baseline
+	// A small tolerance covers test-framework goroutines. The reported bug had
+	// thousands of extra goroutines, so any genuine leak dwarfs this threshold.
+	assert.LessOrEqualf(t, delta, 10,
+		"goroutine leak: %d extra goroutines after %d Start/Close cycles", delta, cycles)
+}
+
+// TestSession_Start_InitTimeoutBoundsStart asserts that Start's initial hardware
+// configuration is bounded by startInitTimeout. A transport that blocks
+// SetPollingRetries must not delay Start's exit past that bound, and the
+// caller's cancellation is still observed promptly.
+func TestSession_Start_InitTimeoutBoundsStart(t *testing.T) {
+	t.Parallel()
+
+	device, mockTransport := createMockDeviceWithTransport(t)
+	// Block all commands for much longer than startInitTimeout. The delay path
+	// in MockTransport.SendCommand observes ctx cancellation, so the derived
+	// initCtx timeout (or caller cancellation) will unblock it.
+	mockTransport.SetDelay(30 * time.Second)
+
+	session := NewSession(device, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		errCh <- session.Start(ctx)
+	}()
+
+	// Cancel well before startInitTimeout to prove cancellation is observed
+	// promptly even during the bounded init phase.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err, "Start should fail when ctx is cancelled during init")
+	case <-time.After(startInitTimeout + 2*time.Second):
+		t.Fatal("Start did not return within init timeout bound")
+	}
+
+	elapsed := time.Since(start)
+	// Start must return shortly after cancellation, well before the 5s bound.
+	assert.Lessf(t, elapsed, 2*time.Second,
+		"Start took %v to return after cancellation, expected <2s", elapsed)
+
+	require.NoError(t, session.Close())
+}

--- a/transport/i2c/i2c.go
+++ b/transport/i2c/i2c.go
@@ -119,9 +119,16 @@ func New(busName string) (*Transport, error) {
 }
 
 // sleepCtx performs a context-aware sleep. Returns ctx.Err() if context is cancelled.
+// Uses a named timer that is explicitly stopped on cancellation so the underlying
+// runtime timer can be released immediately rather than lingering until it fires.
 func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
 	select {
-	case <-time.After(d):
+	case <-timer.C:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/transport/spi/spi.go
+++ b/transport/spi/spi.go
@@ -173,9 +173,16 @@ func (t *Transport) waitReady() error {
 }
 
 // sleepCtx performs a context-aware sleep. Returns ctx.Err() if context is cancelled.
+// Uses a named timer that is explicitly stopped on cancellation so the underlying
+// runtime timer can be released immediately rather than lingering until it fires.
 func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
 	select {
-	case <-time.After(d):
+	case <-timer.C:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()

--- a/transport/uart/uart.go
+++ b/transport/uart/uart.go
@@ -131,9 +131,16 @@ func New(portName string) (*Transport, error) {
 }
 
 // sleepCtx performs a context-aware sleep. Returns ctx.Err() if context is cancelled.
+// Uses a named timer that is explicitly stopped on cancellation so the underlying
+// runtime timer can be released immediately rather than lingering until it fires.
 func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
 	select {
-	case <-time.After(d):
+	case <-timer.C:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -142,8 +149,10 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 
 // handleNilPort handles the case when port is nil (e.g., in tests).
 func (*Transport) handleNilPort(ctx context.Context) error {
+	timer := time.NewTimer(100 * time.Millisecond)
+	defer timer.Stop()
 	select {
-	case <-time.After(100 * time.Millisecond):
+	case <-timer.C:
 		return errors.New("simulated UART error: no port available")
 	case <-ctx.Done():
 		return ctx.Err()


### PR DESCRIPTION
## Summary

Defensive hardening in response to issue #50 (7318 goroutines and 1.4M cgo calls reported on MiSTer after repeated polling reconnects triggered by SAM configuration failures).

The root cause of the specific leak described in the issue is almost certainly caller-side: `zaparoo-core` spawning `go session.Start(ctx)` goroutines without reliably joining them when Start blocks. However, the library had several soft spots that made the problem worse and made clean recovery harder. This PR fixes them so callers have a fighting chance, and adds regression tests.

### Changes

1. **Bounded init phase in `runPollingLoop`.** The first two commands Start issues (`SetPollingRetries` and `SetTimeout`) ran with the caller's raw context, so a wedged transport could block Start's goroutine for its full device timeout. Introduced `configureInitialHardware` with a 5s `startInitTimeout` derived context.

2. **Replace `time.After` with `time.NewTimer` + `Stop()`** in cancellation-interruptible selects. `time.After` leaves the runtime timer on the heap until it fires; explicit `Stop()` releases it immediately. Changed:
   - `polling/recovery.go` — `AttemptRecovery` backoff
   - `polling/session.go` — `pauseWithAck`, `executeWriteToTag` stabilization
   - `transport/uart/uart.go` — `sleepCtx`, `handleNilPort`
   - `transport/i2c/i2c.go`, `transport/spi/spi.go` — `sleepCtx`

3. **Document the caller contract** in `Session.Start` godoc so callers understand they must run it in a tracked goroutine, cancel context before Close, and join after.

### Regression tests

- `TestSession_Start_NoLeakOnFailedInit` — 50 Start/Close cycles against a mock that fails `RFConfiguration`. Asserts the goroutine count delta stays within tolerance (the reported bug had thousands of extras, so any real leak dwarfs the threshold).
- `TestSession_Start_InitTimeoutBoundsStart` — verifies Start returns promptly after context cancellation even when the transport is blocked during initial hardware setup.

Refs #50.

## Test plan

- [x] `make test` — full suite passes with race detection
- [x] `make lint` — 0 issues
- [x] `make check` — full pre-commit check passes
- [x] New leak test run with `-count=5 -race` is stable
- [x] New tests confirm Start exits within 2s of cancellation under both normal and wedged-transport conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resource management by ensuring timers are properly cleaned up on cancellation, reducing memory leaks.
  * Added initialization timeout bounds to prevent indefinite hangs during startup.

* **Tests**
  * Added tests to verify no resource leaks occur during failed initialization cycles.
  * Added tests to ensure initialization respects timeout constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->