### PR TITLE
fix(mifare): continue-on-error format with classified errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -60,6 +60,15 @@ var (
 	ErrTagIncompatible         = errors.New("tag is incompatible with NDEF formatting")
 	ErrWriteVerificationFailed = errors.New("write verification failed: data mismatch")
 
+	// Tag protocol-level classifications. These categorise the underlying
+	// PN532 error code so callers can branch on the cause of a failure via
+	// errors.Is without parsing raw error codes. They are typically chained
+	// alongside a higher-level sentinel (e.g. ErrTagIncompatible) so the
+	// error chain carries both "what operation failed" and "why".
+	ErrTagTimeout      = errors.New("tag timeout")              // PN532 0x01
+	ErrTagDataMismatch = errors.New("tag data format mismatch") // PN532 0x13
+	ErrTagInvalidState = errors.New("tag in invalid state")     // PN532 0x27
+
 	// Data errors - not retryable
 	ErrInvalidParameter = errors.New("invalid parameter")
 	ErrDataTooLarge     = errors.New("data too large")

--- a/errors.go
+++ b/errors.go
@@ -57,6 +57,7 @@ var (
 	ErrTagEmptyData            = errors.New("tag detected but returned empty data")
 	ErrTagDataCorrupt          = errors.New("tag data appears corrupted")
 	ErrTagUnreliable           = errors.New("tag readings are inconsistent")
+	ErrTagIncompatible         = errors.New("tag is incompatible with NDEF formatting")
 	ErrWriteVerificationFailed = errors.New("write verification failed: data mismatch")
 
 	// Data errors - not retryable

--- a/mifare.go
+++ b/mifare.go
@@ -700,23 +700,13 @@ func (t *MIFARETag) WriteNDEF(ctx context.Context, message *NDEFMessage) error {
 		return sizeErr
 	}
 
-	// A value of 0 means "no sector cap" — either the tag was already formatted
-	// (authenticateWithKeyFallback found the NDEF key on sector 1) or we are
-	// still going to format it below. After formatting, this becomes the number
-	// of contiguous sectors that were successfully re-keyed, which bounds how
-	// much space we can safely use.
-	var usableSectors uint8
-	if authResult.isBlank {
-		formatted, formatErr := t.formatForNDEFWithKey(ctx, authResult.blankKey)
-		if formatErr != nil {
-			return fmt.Errorf("failed to format tag for NDEF: %w", formatErr)
-		}
-		usableSectors = formatted
-		// Reject writes that exceed the actually-formatted capacity rather
-		// than letting writeNDEFData fail partway through.
-		if capErr := t.validatePartialFormatCapacity(data, usableSectors); capErr != nil {
-			return capErr
-		}
+	// A value of 0 means "no sector cap" — the tag was already NDEF-formatted
+	// when authenticateWithKeyFallback found the NDEF key on sector 1. When we
+	// had to format, formatIfNeeded returns the number of contiguous sectors
+	// successfully re-keyed, which bounds how much space we can safely use.
+	usableSectors, err := t.formatIfNeeded(ctx, authResult, data)
+	if err != nil {
+		return err
 	}
 
 	if err := ctx.Err(); err != nil {
@@ -737,6 +727,38 @@ func (t *MIFARETag) WriteNDEF(ctx context.Context, message *NDEFMessage) error {
 
 	// Verify write by reading back and comparing
 	return t.verifyWrittenNDEFData(ctx, data)
+}
+
+// formatIfNeeded runs the blank-tag format flow and the post-format capacity
+// check when the tag arrived blank. It returns the usableSectors cap to thread
+// through the write path (0 meaning "no cap" for already-formatted tags).
+//
+// formatForNDEFWithKey may return (n > 0, non-nil err) when the contiguous run
+// was halted early but sector 1 was still formatted. This helper treats zero
+// formatted sectors as a hard failure and anything else as a usable partial
+// success — the partial-failure error is kept and chained into the capacity
+// rejection when the payload won't fit, so diagnostics surface *why* the run
+// stopped short of the payload size.
+func (t *MIFARETag) formatIfNeeded(
+	ctx context.Context, authResult *authenticationResult, data []byte,
+) (uint8, error) {
+	if !authResult.isBlank {
+		return 0, nil
+	}
+
+	formatted, formatErr := t.formatForNDEFWithKey(ctx, authResult.blankKey)
+	if formatted == 0 {
+		return 0, fmt.Errorf("failed to format tag for NDEF: %w", formatErr)
+	}
+
+	if capErr := t.validatePartialFormatCapacity(data, formatted); capErr != nil {
+		if formatErr != nil {
+			return 0, fmt.Errorf("%w: format stopped early: %w", capErr, formatErr)
+		}
+		return 0, capErr
+	}
+
+	return formatted, nil
 }
 
 // validatePartialFormatCapacity returns an error if the NDEF payload will not
@@ -1634,7 +1656,12 @@ func (t *MIFARETag) formatForNDEFWithKey(ctx context.Context, blankKey []byte) (
 	// Add a small delay to let the tag process the key changes.
 	time.Sleep(t.config.HardwareDelay)
 
-	return contiguous, nil
+	// formatErr is non-nil when the contiguous run was halted early by a
+	// per-sector failure. We still return contiguous > 0 so the caller can
+	// attempt a partial write, but the error is preserved so diagnostics
+	// (and the capacity-rejection path in WriteNDEF) can report *why* the
+	// run stopped where it did.
+	return contiguous, formatErr
 }
 
 // DebugInfo returns detailed debug information about the MIFARE tag

--- a/mifare.go
+++ b/mifare.go
@@ -696,13 +696,26 @@ func (t *MIFARETag) WriteNDEF(ctx context.Context, message *NDEFMessage) error {
 		return err
 	}
 
-	if err := t.validateNDEFSize(data); err != nil {
-		return err
+	if sizeErr := t.validateNDEFSize(data); sizeErr != nil {
+		return sizeErr
 	}
 
+	// A value of 0 means "no sector cap" — either the tag was already formatted
+	// (authenticateWithKeyFallback found the NDEF key on sector 1) or we are
+	// still going to format it below. After formatting, this becomes the number
+	// of contiguous sectors that were successfully re-keyed, which bounds how
+	// much space we can safely use.
+	var usableSectors uint8
 	if authResult.isBlank {
-		if err := t.formatForNDEFWithKey(ctx, authResult.blankKey); err != nil {
-			return fmt.Errorf("failed to format tag for NDEF: %w", err)
+		formatted, formatErr := t.formatForNDEFWithKey(ctx, authResult.blankKey)
+		if formatErr != nil {
+			return fmt.Errorf("failed to format tag for NDEF: %w", formatErr)
+		}
+		usableSectors = formatted
+		// Reject writes that exceed the actually-formatted capacity rather
+		// than letting writeNDEFData fail partway through.
+		if capErr := t.validatePartialFormatCapacity(data, usableSectors); capErr != nil {
+			return capErr
 		}
 	}
 
@@ -710,7 +723,7 @@ func (t *MIFARETag) WriteNDEF(ctx context.Context, message *NDEFMessage) error {
 		return err
 	}
 
-	if err := t.writeNDEFData(ctx, data); err != nil {
+	if err := t.writeNDEFData(ctx, data, usableSectors); err != nil {
 		return err
 	}
 
@@ -724,6 +737,28 @@ func (t *MIFARETag) WriteNDEF(ctx context.Context, message *NDEFMessage) error {
 
 	// Verify write by reading back and comparing
 	return t.verifyWrittenNDEFData(ctx, data)
+}
+
+// validatePartialFormatCapacity returns an error if the NDEF payload will not
+// fit inside the contiguous range of sectors that formatForNDEFWithKey was
+// actually able to rekey. A zero sector count means "no cap" (tag was already
+// formatted before we started) and is always accepted here.
+func (*MIFARETag) validatePartialFormatCapacity(data []byte, usableSectors uint8) error {
+	if usableSectors == 0 {
+		return nil
+	}
+	// Sectors 1..usableSectors each expose 3 data blocks (the fourth is the
+	// sector trailer). Large MIFARE 4K sectors are not special-cased here —
+	// this is an upper-bound check and the per-block loop in writeNDEFData
+	// enforces the hard limit.
+	usableBytes := int(usableSectors) * 3 * mifareBlockSize
+	if len(data) > usableBytes {
+		return fmt.Errorf(
+			"%w: NDEF payload is %d bytes but only %d sectors (%d bytes) could be formatted",
+			ErrTagIncompatible, len(data), usableSectors, usableBytes,
+		)
+	}
+	return nil
 }
 
 type authenticationResult struct {
@@ -890,13 +925,30 @@ func (t *MIFARETag) validateNDEFSize(data []byte) error {
 	return nil
 }
 
-func (t *MIFARETag) writeNDEFData(ctx context.Context, data []byte) error {
+// writeNDEFData writes NDEF bytes sequentially to data blocks starting at
+// sector 1 block 0 (block 4). It skips sector trailers and, when usableSectors
+// is non-zero, refuses to touch any sector beyond that bound — this keeps
+// partially formatted tags from failing halfway through with an opaque auth
+// error. A usableSectors value of 0 means "no cap", matching the pre-existing
+// behaviour for tags that were already NDEF-formatted before this call.
+func (t *MIFARETag) writeNDEFData(ctx context.Context, data []byte, usableSectors uint8) error {
 	// Determine max blocks based on card type
 	var maxBlocks uint8
 	if t.IsMIFARE4K() {
 		maxBlocks = 255 // 4K card has 255 blocks (0-254)
 	} else {
 		maxBlocks = 64 // 1K card has 64 blocks (0-63)
+	}
+
+	// When we only successfully formatted a subset of sectors, cap the highest
+	// data block we are willing to touch. Sector N holds blocks N*4..N*4+3 on
+	// MIFARE 1K; we allow up to block (usableSectors+1)*4 exclusive so that
+	// sector `usableSectors` is fully usable.
+	if usableSectors > 0 {
+		capBlock := (usableSectors + 1) * 4
+		if capBlock < maxBlocks {
+			maxBlocks = capBlock
+		}
 	}
 
 	block := uint8(4)
@@ -910,7 +962,8 @@ func (t *MIFARETag) writeNDEFData(ctx context.Context, data []byte) error {
 		}
 
 		if block >= maxBlocks {
-			return errors.New("NDEF data exceeds tag capacity")
+			return fmt.Errorf("%w: insufficient formatted capacity for NDEF payload",
+				ErrTagIncompatible)
 		}
 
 		if err := t.writeDataBlock(ctx, block, data, i); err != nil {
@@ -1424,7 +1477,7 @@ func (*MIFARETag) AnalyzeLastError(err error) string {
 	return fmt.Sprintf("Generic error: %s", errStr)
 }
 
-// formatForNDEFWithKey formats a blank MIFARE Classic tag for NDEF use with a specific blank key
+// determineMaxSectors returns the number of sectors on the tag based on capacity.
 func (t *MIFARETag) determineMaxSectors() uint8 {
 	if t.IsMIFARE4K() {
 		return 40 // MIFARE Classic 4K has 40 sectors (0-39)
@@ -1470,33 +1523,96 @@ func clearKeyBytes(keyBytes []byte) {
 	}
 }
 
-func (t *MIFARETag) formatForNDEFWithKey(ctx context.Context, blankKey []byte) error {
+// classifyFormatError returns a user-friendly classification of a format failure
+// based on the underlying PN532 error code. This helps callers (and users) tell
+// apart "tag was removed" from "tag structure incompatible" from "authentication
+// failure" without having to interpret raw protocol errors.
+func classifyFormatError(err error) string {
+	var pn532Err *PN532Error
+	if errors.As(err, &pn532Err) {
+		switch pn532Err.ErrorCode {
+		case 0x01:
+			return "write timed out — tag may have been removed or is in an error state"
+		case 0x13:
+			return "tag format incompatible — non-standard MIFARE variant or clone"
+		case 0x14:
+			return "authentication failed — tag may have custom keys or be access-protected"
+		case 0x27:
+			return "tag state invalid — try repositioning the card"
+		}
+	}
+	return "unknown format error"
+}
+
+// formatForNDEFWithKey formats a blank MIFARE Classic tag for NDEF use, rewriting
+// each sector trailer's Key A and Key B to the NDEF standard key. It stops at the
+// first sector where formatting fails (rather than aborting the entire operation)
+// and returns the number of contiguous sectors successfully formatted starting
+// from sector 1. A return value of 0 means sector 1 itself could not be formatted
+// — the caller should treat this as a hard failure and surface the classified
+// error via ErrTagIncompatible.
+//
+// Sectors that already contain the NDEF key are counted as formatted. Sectors
+// whose blank-key auth succeeds but whose trailer rewrite fails halt the
+// contiguous run and cause this function to return the count so far along with
+// the underlying error wrapped by the caller.
+func (t *MIFARETag) formatForNDEFWithKey(ctx context.Context, blankKey []byte) (uint8, error) {
 	maxSectors := t.determineMaxSectors()
 	ndefKeyBytes := t.ndefKey.bytes()
+	defer clearKeyBytes(ndefKeyBytes)
+
+	var (
+		contiguous uint8
+		formatErr  error
+	)
 
 	for sector := uint8(1); sector < maxSectors; sector++ {
-		// First authenticate with the blank key
+		if err := ctx.Err(); err != nil {
+			return contiguous, err
+		}
+
+		// Authenticate with the blank key. If that fails, check whether the
+		// sector already holds the NDEF key (treated as already-formatted).
 		if err := t.AuthenticateWithRetry(ctx, sector, MIFAREKeyA, blankKey); err != nil {
-			// If we can't authenticate, assume this sector is already formatted or protected
-			continue
+			if alreadyErr := t.AuthenticateWithRetry(ctx, sector, MIFAREKeyA, ndefKeyBytes); alreadyErr == nil {
+				contiguous++
+				continue
+			}
+			// Sector has custom keys or is otherwise inaccessible. Stop the
+			// contiguous run here — we preserve whatever was formatted up to
+			// this point for callers that can use a partially formatted tag.
+			formatErr = err
+			break
 		}
 
 		if err := t.updateSectorKeys(ctx, sector, ndefKeyBytes); err != nil {
-			return err
+			formatErr = err
+			break
 		}
 
 		if err := t.reAuthenticateWithNDEFKey(ctx, sector, ndefKeyBytes); err != nil {
-			clearKeyBytes(ndefKeyBytes)
-			return err
+			formatErr = err
+			break
 		}
+
+		contiguous++
 	}
 
-	clearKeyBytes(ndefKeyBytes)
+	if contiguous == 0 {
+		// Sector 1 could not be formatted. Surface a clear, classified error so
+		// callers and support can distinguish "tag removed" from "tag format
+		// incompatible" from "authentication failure" at a glance.
+		if formatErr == nil {
+			formatErr = errors.New("no accessible sectors")
+		}
+		return 0, fmt.Errorf("%w: %s: %w",
+			ErrTagIncompatible, classifyFormatError(formatErr), formatErr)
+	}
 
-	// Add a small delay to let the tag process the key changes
+	// Add a small delay to let the tag process the key changes.
 	time.Sleep(t.config.HardwareDelay)
 
-	return nil
+	return contiguous, nil
 }
 
 // DebugInfo returns detailed debug information about the MIFARE tag

--- a/mifare.go
+++ b/mifare.go
@@ -1523,25 +1523,41 @@ func clearKeyBytes(keyBytes []byte) {
 	}
 }
 
-// classifyFormatError returns a user-friendly classification of a format failure
-// based on the underlying PN532 error code. This helps callers (and users) tell
-// apart "tag was removed" from "tag structure incompatible" from "authentication
-// failure" without having to interpret raw protocol errors.
-func classifyFormatError(err error) string {
-	var pn532Err *PN532Error
-	if errors.As(err, &pn532Err) {
-		switch pn532Err.ErrorCode {
-		case 0x01:
-			return "write timed out — tag may have been removed or is in an error state"
-		case 0x13:
-			return "tag format incompatible — non-standard MIFARE variant or clone"
-		case 0x14:
-			return "authentication failed — tag may have custom keys or be access-protected"
-		case 0x27:
-			return "tag state invalid — try repositioning the card"
-		}
+// wrapSector1FormatFailure wraps a sector-1 format failure with the
+// operation-level sentinel ErrTagIncompatible and, when the underlying cause
+// is a classified PN532 error, chains the matching classification sentinel
+// (e.g. ErrTagAuthFailed, ErrTagDataMismatch) so callers can distinguish
+// causes via errors.Is without inspecting raw error codes.
+func wrapSector1FormatFailure(cause error) error {
+	if cause == nil {
+		cause = errors.New("no accessible sectors")
 	}
-	return "unknown format error"
+	if sentinel := classifyPN532Error(cause); sentinel != nil {
+		return fmt.Errorf("%w: %w: %w", ErrTagIncompatible, sentinel, cause)
+	}
+	return fmt.Errorf("%w: %w", ErrTagIncompatible, cause)
+}
+
+// classifyPN532Error maps a PN532 protocol error code onto one of the tag
+// classification sentinels (ErrTagTimeout, ErrTagDataMismatch, ErrTagAuthFailed,
+// ErrTagInvalidState) so callers can branch on the cause via errors.Is. Returns
+// nil if err does not contain a *PN532Error or the code is not classified.
+func classifyPN532Error(err error) error {
+	var pn532Err *PN532Error
+	if !errors.As(err, &pn532Err) {
+		return nil
+	}
+	switch pn532Err.ErrorCode {
+	case 0x01:
+		return ErrTagTimeout
+	case 0x13:
+		return ErrTagDataMismatch
+	case 0x14:
+		return ErrTagAuthFailed
+	case 0x27:
+		return ErrTagInvalidState
+	}
+	return nil
 }
 
 // formatForNDEFWithKey formats a blank MIFARE Classic tag for NDEF use, rewriting
@@ -1549,8 +1565,8 @@ func classifyFormatError(err error) string {
 // first sector where formatting fails (rather than aborting the entire operation)
 // and returns the number of contiguous sectors successfully formatted starting
 // from sector 1. A return value of 0 means sector 1 itself could not be formatted
-// — the caller should treat this as a hard failure and surface the classified
-// error via ErrTagIncompatible.
+// and the returned error wraps ErrTagIncompatible + a classification sentinel
+// (when applicable) around the underlying failure.
 //
 // Sectors that already contain the NDEF key are counted as formatted. Sectors
 // whose blank-key auth succeeds but whose trailer rewrite fails halt the
@@ -1599,14 +1615,7 @@ func (t *MIFARETag) formatForNDEFWithKey(ctx context.Context, blankKey []byte) (
 	}
 
 	if contiguous == 0 {
-		// Sector 1 could not be formatted. Surface a clear, classified error so
-		// callers and support can distinguish "tag removed" from "tag format
-		// incompatible" from "authentication failure" at a glance.
-		if formatErr == nil {
-			formatErr = errors.New("no accessible sectors")
-		}
-		return 0, fmt.Errorf("%w: %s: %w",
-			ErrTagIncompatible, classifyFormatError(formatErr), formatErr)
+		return 0, wrapSector1FormatFailure(formatErr)
 	}
 
 	// Add a small delay to let the tag process the key changes.

--- a/mifare.go
+++ b/mifare.go
@@ -727,7 +727,7 @@ func (t *MIFARETag) WriteNDEF(ctx context.Context, message *NDEFMessage) error {
 		return err
 	}
 
-	if err := t.clearRemainingBlocks(ctx, t.calculateNextBlock(len(data))); err != nil {
+	if err := t.clearRemainingBlocks(ctx, t.calculateNextBlock(len(data)), usableSectors); err != nil {
 		return err
 	}
 
@@ -925,6 +925,36 @@ func (t *MIFARETag) validateNDEFSize(data []byte) error {
 	return nil
 }
 
+// maxWritableBlocks returns the exclusive upper bound on block indices that
+// NDEF write operations may touch. It starts from the tag size (64 for 1K,
+// 255 for 4K) and, when usableSectors is non-zero, further bounds the result
+// so sectors beyond the successfully-formatted contiguous run are never walked.
+// A usableSectors value of 0 means "no cap" (the tag was already NDEF-formatted
+// before this call).
+//
+// NOTE: the cap formula (usableSectors+1)*4 assumes 4-block sectors throughout,
+// which is correct for MIFARE 1K and sectors 0..31 on 4K. Sectors 32..39 on 4K
+// have 16 blocks each; this helper does not special-case them because the
+// format path (updateSectorKeys, WriteBlockAuto sector arithmetic, etc.) does
+// not yet support large sectors either, so usableSectors can never exceed 31
+// on a 4K tag in practice. Fixing the full 4K large-sector geometry is tracked
+// as a separate follow-up.
+func (t *MIFARETag) maxWritableBlocks(usableSectors uint8) uint8 {
+	var maxBlocks uint8
+	if t.IsMIFARE4K() {
+		maxBlocks = 255 // 4K card has 255 blocks (0-254)
+	} else {
+		maxBlocks = 64 // 1K card has 64 blocks (0-63)
+	}
+	if usableSectors > 0 {
+		capBlock := (usableSectors + 1) * 4
+		if capBlock < maxBlocks {
+			maxBlocks = capBlock
+		}
+	}
+	return maxBlocks
+}
+
 // writeNDEFData writes NDEF bytes sequentially to data blocks starting at
 // sector 1 block 0 (block 4). It skips sector trailers and, when usableSectors
 // is non-zero, refuses to touch any sector beyond that bound — this keeps
@@ -932,24 +962,7 @@ func (t *MIFARETag) validateNDEFSize(data []byte) error {
 // error. A usableSectors value of 0 means "no cap", matching the pre-existing
 // behaviour for tags that were already NDEF-formatted before this call.
 func (t *MIFARETag) writeNDEFData(ctx context.Context, data []byte, usableSectors uint8) error {
-	// Determine max blocks based on card type
-	var maxBlocks uint8
-	if t.IsMIFARE4K() {
-		maxBlocks = 255 // 4K card has 255 blocks (0-254)
-	} else {
-		maxBlocks = 64 // 1K card has 64 blocks (0-63)
-	}
-
-	// When we only successfully formatted a subset of sectors, cap the highest
-	// data block we are willing to touch. Sector N holds blocks N*4..N*4+3 on
-	// MIFARE 1K; we allow up to block (usableSectors+1)*4 exclusive so that
-	// sector `usableSectors` is fully usable.
-	if usableSectors > 0 {
-		capBlock := (usableSectors + 1) * 4
-		if capBlock < maxBlocks {
-			maxBlocks = capBlock
-		}
-	}
+	maxBlocks := t.maxWritableBlocks(usableSectors)
 
 	block := uint8(4)
 	for i := 0; i < len(data); i += mifareBlockSize {
@@ -1005,15 +1018,15 @@ func (*MIFARETag) calculateNextBlock(dataLen int) uint8 {
 // clearRemainingBlocks clears data blocks after NDEF data (best-effort).
 // Write failures to non-essential blocks are intentionally ignored.
 //
+// When usableSectors is non-zero, the cleanup is capped to the same bound
+// writeNDEFData uses, so sectors beyond the successfully-formatted contiguous
+// run are never walked. Prior to this cap the cleanup relied on auth failing
+// at the unformatted boundary to stop the best-effort loop — correct by
+// accident, not by construction — so the cap makes the invariant explicit.
+//
 //nolint:nilerr // Intentional: write errors are ignored for best-effort clearing
-func (t *MIFARETag) clearRemainingBlocks(ctx context.Context, startBlock uint8) error {
-	// Determine max blocks based on card type
-	var maxBlocks uint8
-	if t.IsMIFARE4K() {
-		maxBlocks = 255 // 4K card has 255 blocks (0-254)
-	} else {
-		maxBlocks = 64 // 1K card has 64 blocks (0-63)
-	}
+func (t *MIFARETag) clearRemainingBlocks(ctx context.Context, startBlock, usableSectors uint8) error {
+	maxBlocks := t.maxWritableBlocks(usableSectors)
 
 	block := startBlock
 	for block < maxBlocks {

--- a/mifare_test.go
+++ b/mifare_test.go
@@ -1135,60 +1135,60 @@ func TestMIFARETag_FormatForNDEF(t *testing.T) {
 	}
 }
 
-// --- Issue #49 regression tests: Mifare Classic partial-format + classification ---
+// --- Issue #49 regression tests: Mifare Classic partial-format ---
 
-func TestClassifyFormatError(t *testing.T) {
+func TestClassifyPN532Error(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		err      error
-		name     string
-		contains string
+		err  error
+		want error
+		name string
 	}{
 		{
-			name:     "timeout_0x01",
-			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x01},
-			contains: "write timed out",
+			name: "timeout_0x01",
+			err:  &PN532Error{Command: "InDataExchange", ErrorCode: 0x01},
+			want: ErrTagTimeout,
 		},
 		{
-			name:     "dataformat_mismatch_0x13",
-			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x13},
-			contains: "non-standard MIFARE variant or clone",
+			name: "dataformat_mismatch_0x13",
+			err:  &PN532Error{Command: "InDataExchange", ErrorCode: 0x13},
+			want: ErrTagDataMismatch,
 		},
 		{
-			name:     "auth_failed_0x14",
-			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x14},
-			contains: "authentication failed",
+			name: "auth_failed_0x14",
+			err:  &PN532Error{Command: "InDataExchange", ErrorCode: 0x14},
+			want: ErrTagAuthFailed,
 		},
 		{
-			name:     "wrong_context_0x27",
-			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x27},
-			contains: "tag state invalid",
+			name: "wrong_context_0x27",
+			err:  &PN532Error{Command: "InDataExchange", ErrorCode: 0x27},
+			want: ErrTagInvalidState,
 		},
 		{
-			name:     "unknown_pn532_code",
-			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x99},
-			contains: "unknown format error",
+			name: "unclassified_pn532_code",
+			err:  &PN532Error{Command: "InDataExchange", ErrorCode: 0x99},
+			want: nil,
 		},
 		{
-			name: "wrapped_pn532_error",
-			err: fmt.Errorf("tag write failed (block 7): %w",
+			name: "wrapped_pn532_error_still_classifies",
+			err: fmt.Errorf("block 7 write failed: %w",
 				&PN532Error{Command: "InDataExchange", ErrorCode: 0x13}),
-			contains: "non-standard MIFARE variant or clone",
+			want: ErrTagDataMismatch,
 		},
 		{
-			name:     "non_pn532_error",
-			err:      errors.New("some other error"),
-			contains: "unknown format error",
+			name: "non_pn532_error",
+			err:  errors.New("something else"),
+			want: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := classifyFormatError(tt.err)
-			assert.Contains(t, got, tt.contains,
-				"classifyFormatError should classify error into user-friendly text")
+			got := classifyPN532Error(tt.err)
+			assert.Equal(t, tt.want, got,
+				"classifyPN532Error should return the matching sentinel")
 		})
 	}
 }
@@ -1283,11 +1283,13 @@ func TestMIFARETag_FormatForNDEFWithKey_NoAccessibleSector1(t *testing.T) {
 		"sector 1 failure must surface as ErrTagIncompatible")
 }
 
-// TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorSurfacesClassification asserts
-// that when sector 1 fails with a *PN532Error carrying a known code (0x13
-// dataformat mismatch, the failure mode reported in issue #49), the wrapped
-// error contains the user-facing classification string.
-func TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorSurfacesClassification(t *testing.T) {
+// TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorChainsSentinel asserts that
+// when sector 1 fails with a *PN532Error (0x13 dataformat mismatch, the
+// failure mode reported in issue #49), the returned error chain contains
+// both ErrTagIncompatible (the operation-level sentinel) and ErrTagDataMismatch
+// (the classification sentinel) so callers can branch on cause with
+// errors.Is, and the raw *PN532Error is still reachable via errors.As.
+func TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorChainsSentinel(t *testing.T) {
 	t.Parallel()
 
 	tag, mt := setupMIFARETagTest(t, func(_ *MockTransport) {})
@@ -1298,9 +1300,15 @@ func TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorSurfacesClassification(t *test
 	_, err := tag.formatForNDEFWithKey(context.Background(), blankKey)
 
 	require.Error(t, err)
-	require.ErrorIs(t, err, ErrTagIncompatible)
-	assert.Contains(t, err.Error(), "non-standard MIFARE variant or clone",
-		"classified error message should be surfaced through the error chain")
+	require.ErrorIs(t, err, ErrTagIncompatible,
+		"error chain must include the operation-level sentinel")
+	require.ErrorIs(t, err, ErrTagDataMismatch,
+		"error chain must include the classification sentinel")
+
+	var pn532Err *PN532Error
+	require.ErrorAs(t, err, &pn532Err,
+		"underlying *PN532Error must remain unwrappable through the error chain")
+	assert.Equal(t, uint8(0x13), pn532Err.ErrorCode)
 }
 
 func TestMIFARETag_WriteNDEFAlternative(t *testing.T) {

--- a/mifare_test.go
+++ b/mifare_test.go
@@ -18,6 +18,7 @@ package pn532
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1132,6 +1133,174 @@ func TestMIFARETag_FormatForNDEF(t *testing.T) {
 			checkMIFARETagError(t, err, tt.expectError, tt.errorContains)
 		})
 	}
+}
+
+// --- Issue #49 regression tests: Mifare Classic partial-format + classification ---
+
+func TestClassifyFormatError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		err      error
+		name     string
+		contains string
+	}{
+		{
+			name:     "timeout_0x01",
+			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x01},
+			contains: "write timed out",
+		},
+		{
+			name:     "dataformat_mismatch_0x13",
+			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x13},
+			contains: "non-standard MIFARE variant or clone",
+		},
+		{
+			name:     "auth_failed_0x14",
+			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x14},
+			contains: "authentication failed",
+		},
+		{
+			name:     "wrong_context_0x27",
+			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x27},
+			contains: "tag state invalid",
+		},
+		{
+			name:     "unknown_pn532_code",
+			err:      &PN532Error{Command: "InDataExchange", ErrorCode: 0x99},
+			contains: "unknown format error",
+		},
+		{
+			name: "wrapped_pn532_error",
+			err: fmt.Errorf("tag write failed (block 7): %w",
+				&PN532Error{Command: "InDataExchange", ErrorCode: 0x13}),
+			contains: "non-standard MIFARE variant or clone",
+		},
+		{
+			name:     "non_pn532_error",
+			err:      errors.New("some other error"),
+			contains: "unknown format error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyFormatError(tt.err)
+			assert.Contains(t, got, tt.contains,
+				"classifyFormatError should classify error into user-friendly text")
+		})
+	}
+}
+
+func TestMIFARETag_ValidatePartialFormatCapacity(t *testing.T) {
+	t.Parallel()
+
+	tag, _ := setupMIFARETagTest(t, func(_ *MockTransport) {})
+
+	tests := []struct {
+		name          string
+		dataLen       int
+		usableSectors uint8
+		wantErr       bool
+	}{
+		{
+			name:          "no_cap_means_always_ok",
+			dataLen:       4096,
+			usableSectors: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "one_sector_fits_small_ndef",
+			dataLen:       40, // fits in 3 data blocks (48 bytes)
+			usableSectors: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "one_sector_exactly_48_bytes",
+			dataLen:       48,
+			usableSectors: 1,
+			wantErr:       false,
+		},
+		{
+			name:          "one_sector_overflow",
+			dataLen:       49,
+			usableSectors: 1,
+			wantErr:       true,
+		},
+		{
+			name:          "two_sectors_fits_96_bytes",
+			dataLen:       96,
+			usableSectors: 2,
+			wantErr:       false,
+		},
+		{
+			name:          "two_sectors_overflow",
+			dataLen:       97,
+			usableSectors: 2,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data := make([]byte, tt.dataLen)
+			err := tag.validatePartialFormatCapacity(data, tt.usableSectors)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrTagIncompatible,
+					"over-capacity payload must wrap ErrTagIncompatible")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestMIFARETag_FormatForNDEFWithKey_NoAccessibleSector1 verifies that when
+// sector 1 cannot be authenticated with either the blank key or the NDEF key
+// (because the mock rejects every InDataExchange command), formatForNDEFWithKey
+// returns (0, ErrTagIncompatible wrapped) rather than a silent success or an
+// opaque auth error.
+func TestMIFARETag_FormatForNDEFWithKey_NoAccessibleSector1(t *testing.T) {
+	t.Parallel()
+
+	tag, mt := setupMIFARETagTest(t, func(_ *MockTransport) {})
+	tag.SetConfig(testMIFAREConfig())
+	// Reject every InDataExchange command so blank-key and NDEF-key auth both
+	// fail on sector 1. classifyFormatError should fall through to "unknown
+	// format error" because the inner error is not a *PN532Error.
+	mt.SetError(0x40, errors.New("auth refused"))
+
+	blankKey := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+	contiguous, err := tag.formatForNDEFWithKey(context.Background(), blankKey)
+
+	require.Error(t, err)
+	assert.Equal(t, uint8(0), contiguous,
+		"no sectors should have been counted as formatted")
+	assert.ErrorIs(t, err, ErrTagIncompatible,
+		"sector 1 failure must surface as ErrTagIncompatible")
+}
+
+// TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorSurfacesClassification asserts
+// that when sector 1 fails with a *PN532Error carrying a known code (0x13
+// dataformat mismatch, the failure mode reported in issue #49), the wrapped
+// error contains the user-facing classification string.
+func TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorSurfacesClassification(t *testing.T) {
+	t.Parallel()
+
+	tag, mt := setupMIFARETagTest(t, func(_ *MockTransport) {})
+	tag.SetConfig(testMIFAREConfig())
+	mt.SetError(0x40, &PN532Error{Command: "InDataExchange", ErrorCode: 0x13})
+
+	blankKey := []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+	_, err := tag.formatForNDEFWithKey(context.Background(), blankKey)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTagIncompatible)
+	assert.Contains(t, err.Error(), "non-standard MIFARE variant or clone",
+		"classified error message should be surfaced through the error chain")
 }
 
 func TestMIFARETag_WriteNDEFAlternative(t *testing.T) {

--- a/mifare_test.go
+++ b/mifare_test.go
@@ -1258,6 +1258,78 @@ func TestMIFARETag_ValidatePartialFormatCapacity(t *testing.T) {
 	}
 }
 
+// TestMIFARETag_MaxWritableBlocks verifies the block-cap helper used by both
+// writeNDEFData and clearRemainingBlocks. The two call sites must agree on the
+// exclusive upper bound so partial-format cleanup never walks past the sectors
+// that formatForNDEFWithKey actually rekeyed.
+func TestMIFARETag_MaxWritableBlocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		usableSectors uint8
+		is4K          bool
+		want          uint8
+	}{
+		{
+			name:          "1K_no_cap",
+			is4K:          false,
+			usableSectors: 0,
+			want:          64,
+		},
+		{
+			name:          "1K_cap_1_sector",
+			is4K:          false,
+			usableSectors: 1,
+			want:          8, // sector 1 occupies blocks 4..7
+		},
+		{
+			name:          "1K_cap_2_sectors",
+			is4K:          false,
+			usableSectors: 2,
+			want:          12, // sector 2 occupies blocks 8..11
+		},
+		{
+			name:          "1K_cap_larger_than_tag_clamps_to_64",
+			is4K:          false,
+			usableSectors: 20,
+			want:          64,
+		},
+		{
+			name:          "4K_no_cap",
+			is4K:          true,
+			usableSectors: 0,
+			want:          255,
+		},
+		{
+			name:          "4K_cap_1_sector",
+			is4K:          true,
+			usableSectors: 1,
+			want:          8,
+		},
+		{
+			name:          "4K_cap_31_sectors",
+			is4K:          true,
+			usableSectors: 31,
+			want:          128, // last of the small-sector region
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			device := createMockDevice(t)
+			sak := byte(0x08)
+			if tt.is4K {
+				sak = 0x18
+			}
+			tag := newTestMIFARETag(device, []byte{0x04, 0x12, 0x34, 0x56}, sak)
+			got := tag.maxWritableBlocks(tt.usableSectors)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestMIFARETag_FormatForNDEFWithKey_NoAccessibleSector1 verifies that when
 // sector 1 cannot be authenticated with either the blank key or the NDEF key
 // (because the mock rejects every InDataExchange command), formatForNDEFWithKey


### PR DESCRIPTION
## Summary

Mifare Classic `WriteNDEF` previously aborted the entire format on the first sector where the trailer could not be read or written. Sentry reported ~40 occurrences from zaparoo-core users, with error 0x01 (timeout) and 0x13 (dataformat mismatch) on sector 1 trailer writes. Tags where sectors 2+ fail but sector 1 is usable for a small NDEF payload were getting a hard failure instead of a partial success.

### Behavior changes

- **`formatForNDEFWithKey`** now tracks the number of contiguous sectors successfully formatted from sector 1 onward. It stops at the first failure rather than aborting, and returns the count along with an error only when sector 1 itself cannot be formatted. Sectors that already contain the NDEF key are counted as formatted.
- **`WriteNDEF`** performs a post-format capacity check (`validatePartialFormatCapacity`) before writing: if the NDEF payload won't fit in the sectors that actually formatted, it fails fast with a clear `ErrTagIncompatible` error instead of failing partway through `writeNDEFData`.
- **`writeNDEFData`** accepts a `usableSectors` cap. When non-zero it refuses to touch sectors beyond the bound, so partially formatted tags never hit an unformatted sector mid-write.

### New sentinel errors

`errors.go` now exposes classified tag-failure sentinels alongside the existing `ErrTagAuthFailed`:

- `ErrTagIncompatible`  — operation-level: tag cannot be formatted for NDEF
- `ErrTagTimeout`       — PN532 0x01 (write timed out; tag may have been removed)
- `ErrTagDataMismatch`  — PN532 0x13 (data format mismatch; non-standard variant/clone)
- `ErrTagInvalidState`  — PN532 0x27 (wrong context; RF instability)

Sector-1 format failures are wrapped as `ErrTagIncompatible` + the matching classification sentinel + the underlying `*PN532Error`, so callers can branch structurally with `errors.Is` without parsing prose:

```go
if errors.Is(err, pn532.ErrTagIncompatible) {
    switch {
    case errors.Is(err, pn532.ErrTagAuthFailed):    // custom keys
    case errors.Is(err, pn532.ErrTagDataMismatch):  // non-standard clone
    case errors.Is(err, pn532.ErrTagTimeout):       // tag removed mid-write
    case errors.Is(err, pn532.ErrTagInvalidState):  // RF instability
    }
}
```

The raw `*PN532Error` remains reachable through the chain via `errors.As`. Rendering user-facing text from these categories is the caller's responsibility — the library does not bundle advisory strings into wrapped errors.

Refs #49.

### Follow-up (not in this PR)

- **Latent 4K sector addressing bug**: `trailerBlock := sector*4 + 3` at `mifare.go:1489` is wrong for sectors 32-39 on 4K tags (large sectors have 16 blocks each). This is a separate bug discovered during investigation; will open a follow-up issue.
- **Access-bit parsing**: considered but not included. The reported errors (0x01, 0x13) aren't access-bit failures, so parsing them gives no predictive power.

## Test plan

- [x] `make test` — full suite passes with race detection
- [x] `make lint` — 0 issues
- [x] `make check` — full pre-commit check passes
- [x] New `TestClassifyPN532Error` covers every classified code (0x01/0x13/0x14/0x27), an unclassified code, a wrapped `*PN532Error`, and a non-PN532 error — asserting sentinel identity rather than prose
- [x] New `TestMIFARETag_ValidatePartialFormatCapacity` validates single- and multi-sector caps at exact boundaries
- [x] New `TestMIFARETag_FormatForNDEFWithKey_NoAccessibleSector1` asserts sector 1 auth failure surfaces as `ErrTagIncompatible`
- [x] New `TestMIFARETag_FormatForNDEFWithKey_Pn532ErrorChainsSentinel` asserts a `*PN532Error` with code 0x13 produces an error chain containing `ErrTagIncompatible` + `ErrTagDataMismatch`, with the raw `*PN532Error` reachable via `errors.As`
- [x] Existing `TestMIFARETag_WriteNDEF` and `TestMIFARETag_FormatForNDEF` pass unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced four new sentinel error values for finer error handling (tag incompatibility, timeouts, data mismatch, invalid state).

* **Bug Fixes**
  * Improved MIFARE write flow with robust capacity checks, partial-sector formatting, and capped cleanup to avoid overruns.
  * Enhanced error classification to surface more informative, chainable errors.

* **Tests**
  * Added regression tests covering partial-format behavior, capacity checks, writable bounds, and error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->