### PR TITLE
ci: run pr-title workflow under pull_request to attach check to PR head

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,11 +1,21 @@
 name: PR Title Validation
 
+# Runs under pull_request (not pull_request_target) so the resulting check
+# run is attached to the PR head commit. The repository ruleset requires a
+# "Validate PR Title" check on the PR head; pull_request_target attached it
+# to the base branch's commit instead, which left PRs stuck on
+# "waiting for status to be reported". See #67 for the incident.
+#
+# This workflow does not check out PR code and does not need secrets beyond
+# the default GITHUB_TOKEN, so pull_request is the safer and correct trigger.
+
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - reopened
+      - synchronize
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
## Summary

The ruleset on \`main\` requires a \"Validate PR Title\" status check on the **PR head commit**. The existing workflow used \`pull_request_target\`, which runs in the context of the base branch and creates check runs against the base commit, not the PR head. The ruleset inspects the PR head, finds no check with that name, and leaves PRs stuck on \"waiting for status to be reported\" indefinitely — only admins with bypass rights could merge.

Observed on #66, #67, #68: all three are currently blocked by this exact symptom.

### Changes

- Switch \`on:\` from \`pull_request_target\` to \`pull_request\`. The check run is now attached to the PR head where the ruleset looks for it.
- Add \`synchronize\` to the trigger types so the title check re-runs when new commits land on a PR (catches title edits through rebases/force-pushes).

### Why pull_request is safe here

The workflow only reads \`github.event.pull_request.title\` via \`amannn/action-semantic-pull-request\`. It does not check out PR code, run user-controlled scripts, or need secrets beyond the default \`GITHUB_TOKEN\`. \`pull_request\` is both safer (runs in the fork's context with no secret access on forked PRs) and correct for this use case.

### Bootstrapping note

This PR itself will hit the same \"waiting for status to be reported\" block when opened, because the ruleset is still expecting the check and the old \`pull_request_target\` workflow is still what's on \`main\`. **Admin bypass is required to merge this one PR** — once merged, subsequent PRs will work normally.

## Test plan

- [x] Confirmed via \`gh api .../commits/\$HEAD/check-runs\` that \"Validate PR Title\" is absent from #67's head commit despite the workflow reporting \`success\` under \`pull_request_target\`
- [x] Confirmed the ruleset's \`required_status_checks\` list contains \`Validate PR Title\` (exact context name)
- [ ] After merging, open a fresh PR and verify the check attaches to the head commit and satisfies the ruleset without admin bypass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request title validation to trigger when commits are pushed to pull requests, enabling validation feedback at additional points in the PR development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->