### PR TITLE
fix(device): make auto-detection best-effort across candidates

### DIFF
--- a/device.go
+++ b/device.go
@@ -206,13 +206,6 @@ func applyConnectOptions(opts []ConnectOption) (*connectConfig, error) {
 	return config, nil
 }
 
-func createTransport(ctx context.Context, path string, config *connectConfig) (Transport, error) {
-	if config.autoDetect || path == "" {
-		return createAutoDetectedTransport(ctx, config.transportDeviceFactory, config.deviceDetector)
-	}
-	return createManualTransport(path, config.transportFactory)
-}
-
 func setupDevice(ctx context.Context, transport Transport, config *connectConfig) (*Device, error) {
 	device, err := New(transport, config.deviceOptions...)
 	if err != nil {
@@ -232,14 +225,11 @@ func setupDevice(ctx context.Context, transport Transport, config *connectConfig
 	return device, nil
 }
 
-// setupDeviceWithRetry wraps setupDevice with retry logic for connection attempts
+// setupDeviceWithRetry wraps setupDevice with retry logic for manual
+// connections. Auto-detection does not use this path — it tries each detected
+// candidate exactly once inside connectAutoDetected so a wedged transport
+// can't burn a retry budget on top of iteration.
 func setupDeviceWithRetry(ctx context.Context, transport Transport, config *connectConfig) (*Device, error) {
-	// Auto-detection should bypass retry logic (single attempt only)
-	if config.autoDetect {
-		return setupDevice(ctx, transport, config)
-	}
-
-	// Manual connections use retry logic
 	retryConfig := &RetryConfig{
 		MaxAttempts:       config.connectionRetries,
 		InitialBackoff:    ConnectionInitialBackoff,
@@ -271,9 +261,22 @@ func ConnectDevice(ctx context.Context, path string, opts ...ConnectOption) (*De
 		return nil, fmt.Errorf("failed to apply connect options: %w", err)
 	}
 
-	transport, err := createTransport(ctx, path, config)
+	if config.autoDetect || path == "" {
+		return connectAutoDetected(ctx, config)
+	}
+	return connectManual(ctx, path, config)
+}
+
+// connectManual builds a transport for an explicit path and runs the retry
+// loop against it. Used when the caller knows exactly which device to open.
+func connectManual(ctx context.Context, path string, config *connectConfig) (*Device, error) {
+	if config.transportFactory == nil {
+		return nil, errors.New("transport factory not provided")
+	}
+
+	transport, err := config.transportFactory(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transport: %w", err)
+		return nil, fmt.Errorf("failed to create transport for path %s: %w", path, err)
 	}
 
 	device, err := setupDeviceWithRetry(ctx, transport, config)
@@ -281,56 +284,94 @@ func ConnectDevice(ctx context.Context, path string, opts ...ConnectOption) (*De
 		_ = transport.Close()
 		return nil, err
 	}
-
 	return device, nil
 }
 
-// createManualTransport handles creation of transport for a specific path
-func createManualTransport(path string, factory TransportFactory) (Transport, error) {
-	if factory == nil {
-		return nil, errors.New("transport factory not provided")
+// connectAutoDetected runs auto-detection and tries each returned candidate
+// in turn, returning the first one that initialises successfully. Detection
+// handing back a Low-confidence candidate (e.g. an I2C bus on a host where
+// no PN532 is actually wired up) must not kill the whole connection attempt
+// — the next candidate gets a chance, and only if every candidate fails do
+// we return a single aggregated error explaining which transports were
+// tried and why each failed.
+//
+// Per-candidate failures are written to the session log via Debugf so they
+// show up when something unexpected happens, but they do not propagate to
+// the caller as long as another candidate succeeds.
+func connectAutoDetected(ctx context.Context, config *connectConfig) (*Device, error) {
+	if config.transportDeviceFactory == nil {
+		return nil, errors.New("transport device factory not provided")
 	}
 
-	transport, err := factory(path)
+	devices, err := runAutoDetection(ctx, config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create transport for path %s: %w", path, err)
+		return nil, err
 	}
 
-	return transport, nil
+	var candidateErrs []error
+	for i := range devices {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		candidate := devices[i]
+		device, tryErr := tryAutoDetectedCandidate(ctx, candidate, config)
+		if tryErr == nil {
+			return device, nil
+		}
+
+		Debugf("auto-detect: skipping %s: %v", candidate.String(), tryErr)
+		candidateErrs = append(candidateErrs, fmt.Errorf("%s: %w", candidate.String(), tryErr))
+	}
+
+	return nil, fmt.Errorf("all %d auto-detected candidate(s) failed to initialise: %w",
+		len(devices), errors.Join(candidateErrs...))
 }
 
-// createAutoDetectedTransport handles auto-detection of devices
-func createAutoDetectedTransport(
-	ctx context.Context,
-	factory TransportFromDeviceFactory,
-	detector func(context.Context, *detection.Options) ([]detection.DeviceInfo, error),
-) (Transport, error) {
+// runAutoDetection invokes whichever detector the caller configured (custom
+// or the default registry-based DetectAll) and normalises the "no devices"
+// outcome so connectAutoDetected's caller always sees a clear error rather
+// than an empty slice.
+func runAutoDetection(ctx context.Context, config *connectConfig) ([]detection.DeviceInfo, error) {
 	opts := detection.DefaultOptions()
 	opts.Mode = detection.Safe
 
-	var devices []detection.DeviceInfo
-	var err error
-
-	if detector != nil {
-		devices, err = detector(ctx, &opts)
+	var (
+		devices []detection.DeviceInfo
+		err     error
+	)
+	if config.deviceDetector != nil {
+		devices, err = config.deviceDetector(ctx, &opts)
 	} else {
 		devices, err = detection.DetectAll(ctx, &opts)
 	}
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect devices: %w", err)
 	}
-
 	if len(devices) == 0 {
 		return nil, errors.New("no PN532 devices found")
 	}
+	return devices, nil
+}
 
-	// Use the first detected device
-	device := devices[0]
-	if factory == nil {
-		return nil, errors.New("transport device factory not provided")
+// tryAutoDetectedCandidate builds a transport for a single detected device
+// and initialises a Device on it. On any failure the transport is closed
+// before returning so failed candidates leak neither file descriptors nor
+// bus locks.
+func tryAutoDetectedCandidate(
+	ctx context.Context, candidate detection.DeviceInfo, config *connectConfig,
+) (*Device, error) {
+	transport, err := config.transportDeviceFactory(candidate)
+	if err != nil {
+		return nil, fmt.Errorf("transport creation: %w", err)
 	}
-	return factory(device)
+
+	device, err := setupDevice(ctx, transport, config)
+	if err != nil {
+		_ = transport.Close()
+		return nil, fmt.Errorf("device init: %w", err)
+	}
+	return device, nil
 }
 
 // Transport returns the underlying transport

--- a/device.go
+++ b/device.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/ZaparooProject/go-pn532/detection"
@@ -308,6 +310,15 @@ func connectAutoDetected(ctx context.Context, config *connectConfig) (*Device, e
 		return nil, err
 	}
 
+	// Prefer quiet transports first. UART and SPI open cleanly on desktop
+	// Linux; periph.io's host.Init() (called on first I2C/SPI transport
+	// construction) loudly logs a /dev/gpiochip0 permission warning via
+	// gpioioctl whenever the user isn't in the gpio group. If UART is
+	// present we never want to touch that code path, so we try UART
+	// candidates before I2C/SPI. This is a transport-kind preference, not
+	// a confidence sort: any working candidate will still win.
+	sortCandidatesByTransportPreference(devices)
+
 	var candidateErrs []error
 	for i := range devices {
 		if err := ctx.Err(); err != nil {
@@ -326,6 +337,40 @@ func connectAutoDetected(ctx context.Context, config *connectConfig) (*Device, e
 
 	return nil, fmt.Errorf("all %d auto-detected candidate(s) failed to initialise: %w",
 		len(devices), errors.Join(candidateErrs...))
+}
+
+// transportPreferenceRank returns the preference rank of a detection
+// Transport string, used to order auto-detect candidates. Lower is tried
+// first. UART comes before SPI comes before I2C so that, when a UART PN532
+// is present, we never construct an I2C/SPI transport and therefore never
+// trigger periph.io's host.Init() (which loudly logs a gpiochip
+// permission-denied warning on hosts where the user isn't in the gpio
+// group). Unknown transports sort last.
+//
+// Matching is case-insensitive to tolerate detector implementations that
+// use different casing conventions for their Transport field.
+func transportPreferenceRank(transport string) int {
+	switch strings.ToLower(transport) {
+	case "uart":
+		return 0
+	case "spi":
+		return 1
+	case "i2c":
+		return 2
+	default:
+		return 3
+	}
+}
+
+// sortCandidatesByTransportPreference reorders the detected devices in
+// place so UART candidates are tried before SPI, and SPI before I2C. This
+// is a transport-kind preference only — it does not re-rank devices of the
+// same transport among themselves (a stable sort preserves the order the
+// detectors returned them in).
+func sortCandidatesByTransportPreference(devices []detection.DeviceInfo) {
+	sort.SliceStable(devices, func(i, j int) bool {
+		return transportPreferenceRank(devices[i].Transport) < transportPreferenceRank(devices[j].Transport)
+	})
 }
 
 // runAutoDetection invokes whichever detector the caller configured (custom

--- a/device.go
+++ b/device.go
@@ -177,18 +177,6 @@ func WithDeviceDetector(
 	}
 }
 
-// ConnectDevice creates and initializes a PN532 device from a path or auto-detection.
-// This is a high-level convenience function that handles transport creation, device
-// initialization, and optional validation setup.
-//
-// Example usage:
-//
-//	// Connect to specific device
-//	device, err := pn532.ConnectDevice("/dev/ttyUSB0")
-//
-//
-//	// Auto-detect device
-//	device, err := pn532.ConnectDevice("", pn532.WithAutoDetection())
 func applyConnectOptions(opts []ConnectOption) (*connectConfig, error) {
 	config := &connectConfig{
 		autoDetect:             false,
@@ -257,6 +245,48 @@ func setupDeviceWithRetry(ctx context.Context, transport Transport, config *conn
 	return device, nil
 }
 
+// ConnectDevice creates and initializes a PN532 device from a path or via
+// auto-detection. It handles transport creation, device initialization, and
+// optional validation setup.
+//
+// The pn532 package does not bundle a default transport — callers must wire up
+// whichever transports they want to link (uart, i2c, spi, or a custom one) and
+// pass the corresponding factory option. This keeps consumers that only need
+// one transport from pulling in the others (and their dependencies).
+//
+// For an explicit device path, pass [WithTransportFactory] with a function that
+// returns the right [Transport] for the given path string:
+//
+//	import (
+//	    pn532 "github.com/ZaparooProject/go-pn532"
+//	    "github.com/ZaparooProject/go-pn532/transport/uart"
+//	)
+//
+//	newTransport := func(path string) (pn532.Transport, error) {
+//	    return uart.New(path)
+//	}
+//	device, err := pn532.ConnectDevice(ctx, "/dev/ttyUSB0",
+//	    pn532.WithTransportFactory(newTransport))
+//
+// For auto-detection, register the detectors you care about via blank import
+// and pass [WithAutoDetection] together with [WithTransportFromDeviceFactory]:
+//
+//	import (
+//	    pn532 "github.com/ZaparooProject/go-pn532"
+//	    "github.com/ZaparooProject/go-pn532/detection"
+//	    _ "github.com/ZaparooProject/go-pn532/detection/uart"
+//	    "github.com/ZaparooProject/go-pn532/transport/uart"
+//	)
+//
+//	newFromDevice := func(info detection.DeviceInfo) (pn532.Transport, error) {
+//	    return uart.New(info.Path)
+//	}
+//	device, err := pn532.ConnectDevice(ctx, "",
+//	    pn532.WithAutoDetection(),
+//	    pn532.WithTransportFromDeviceFactory(newFromDevice))
+//
+// See cmd/reader/main.go for a complete example that supports all three
+// transports.
 func ConnectDevice(ctx context.Context, path string, opts ...ConnectOption) (*Device, error) {
 	config, err := applyConnectOptions(opts)
 	if err != nil {

--- a/device_test.go
+++ b/device_test.go
@@ -512,3 +512,94 @@ func TestConnectDevice_WithConnectionRetries(t *testing.T) {
 		assert.Equal(t, 1, samAttempts, "Auto-detection should only make single attempt")
 	})
 }
+
+// TestConnectDevice_AutoDetect_FallsBackOnInitFailure verifies that
+// auto-detection's candidate iteration does not bail on the first failure:
+// a wedged transport (e.g. an I2C bus without a PN532) must be skipped and
+// the next detected candidate given a chance to initialise.
+func TestConnectDevice_AutoDetect_FallsBackOnInitFailure(t *testing.T) {
+	t.Parallel()
+
+	failing := setupFailingTransport()
+
+	workingMock := NewMockTransport()
+	workingMock.SetResponse(testutil.CmdGetFirmwareVersion, testutil.BuildFirmwareVersionResponse())
+	workingMock.SetResponse(testutil.CmdSAMConfiguration, testutil.BuildSAMConfigurationResponse())
+
+	// Hand out the failing transport first, then the working one. The first
+	// candidate's SAM config fails; the second must be tried and succeed.
+	var factoryCalls int
+	deviceFactory := func(_ detection.DeviceInfo) (Transport, error) {
+		factoryCalls++
+		if factoryCalls == 1 {
+			return failing, nil
+		}
+		return workingMock, nil
+	}
+
+	mockDetector := func(_ context.Context, _ *detection.Options) ([]detection.DeviceInfo, error) {
+		return []detection.DeviceInfo{
+			{Name: "FailingCandidate", Path: "/dev/mock-bad", Transport: "mock"},
+			{Name: "WorkingCandidate", Path: "/dev/mock-good", Transport: "mock"},
+		}, nil
+	}
+
+	device, err := ConnectDevice(context.Background(), "",
+		WithAutoDetection(),
+		WithTransportFromDeviceFactory(deviceFactory),
+		WithDeviceDetector(mockDetector))
+	require.NoError(t, err, "expected fallback to the working candidate")
+	require.NotNil(t, device)
+	defer func() {
+		_ = device.Close()
+	}()
+
+	assert.Equal(t, 2, factoryCalls, "both candidates should have been tried")
+	assert.False(t, failing.IsConnected(),
+		"failed candidate's transport should have been closed on iteration skip")
+	assert.True(t, workingMock.IsConnected(),
+		"succeeding candidate's transport must still be open")
+	assert.Equal(t, 1, failing.(*MockTransport).GetCallCount(testutil.CmdSAMConfiguration),
+		"failed candidate should get exactly one SAM attempt (no retry loop on auto-detect)")
+	assert.Equal(t, 1, workingMock.GetCallCount(testutil.CmdSAMConfiguration),
+		"working candidate should get exactly one SAM attempt")
+}
+
+// TestConnectDevice_AutoDetect_AggregatesWhenAllFail verifies that when every
+// detected candidate fails to initialise, ConnectDevice returns a single
+// aggregated error naming the total candidate count instead of silently
+// hiding the first failure or returning a misleading "no devices" error.
+func TestConnectDevice_AutoDetect_AggregatesWhenAllFail(t *testing.T) {
+	t.Parallel()
+
+	first := setupFailingTransport()
+	second := setupFailingTransport()
+
+	var factoryCalls int
+	deviceFactory := func(_ detection.DeviceInfo) (Transport, error) {
+		factoryCalls++
+		if factoryCalls == 1 {
+			return first, nil
+		}
+		return second, nil
+	}
+
+	mockDetector := func(_ context.Context, _ *detection.Options) ([]detection.DeviceInfo, error) {
+		return []detection.DeviceInfo{
+			{Name: "BadA", Path: "/dev/mock-a", Transport: "mock"},
+			{Name: "BadB", Path: "/dev/mock-b", Transport: "mock"},
+		}, nil
+	}
+
+	device, err := ConnectDevice(context.Background(), "",
+		WithAutoDetection(),
+		WithTransportFromDeviceFactory(deviceFactory),
+		WithDeviceDetector(mockDetector))
+	require.Error(t, err)
+	assert.Nil(t, device)
+	assert.Contains(t, err.Error(), "all 2 auto-detected candidate(s) failed",
+		"aggregated error must surface the total candidate count")
+	assert.Equal(t, 2, factoryCalls, "both candidates should be tried before giving up")
+	assert.False(t, first.IsConnected(), "first failed transport must be closed")
+	assert.False(t, second.IsConnected(), "second failed transport must be closed")
+}

--- a/device_test.go
+++ b/device_test.go
@@ -603,3 +603,92 @@ func TestConnectDevice_AutoDetect_AggregatesWhenAllFail(t *testing.T) {
 	assert.False(t, first.IsConnected(), "first failed transport must be closed")
 	assert.False(t, second.IsConnected(), "second failed transport must be closed")
 }
+
+// TestConnectDevice_AutoDetect_PrefersUARTOverI2C verifies that when the
+// detector returns a mix of transport types, auto-detection tries UART
+// candidates before I2C (and SPI before I2C) so a working UART PN532
+// succeeds without ever constructing an I2C transport. This matters on
+// Linux desktops where the I2C transport's host.Init() call logs a
+// gpioioctl /dev/gpiochip0 permission warning for users not in the gpio
+// group — we want that warning to stay silent whenever UART works.
+func TestConnectDevice_AutoDetect_PrefersUARTOverI2C(t *testing.T) {
+	t.Parallel()
+
+	uartMock := NewMockTransport()
+	uartMock.SetResponse(testutil.CmdGetFirmwareVersion, testutil.BuildFirmwareVersionResponse())
+	uartMock.SetResponse(testutil.CmdSAMConfiguration, testutil.BuildSAMConfigurationResponse())
+
+	// Track which transports the factory was asked to create, in order.
+	var createdTransports []string
+	deviceFactory := func(info detection.DeviceInfo) (Transport, error) {
+		createdTransports = append(createdTransports, info.Transport)
+		// Anything except UART must never actually be constructed; returning
+		// an error if we're asked for one would be fine too, but returning a
+		// bogus transport lets the test fail loudly on the assertions below
+		// if ordering breaks.
+		if info.Transport == "uart" {
+			return uartMock, nil
+		}
+		return NewMockTransport(), nil
+	}
+
+	// Return I2C first (and SPI middle) — whatever the goroutine race
+	// happens to hand back. The sort in connectAutoDetected must reorder
+	// these into uart → spi → i2c before iteration.
+	mockDetector := func(_ context.Context, _ *detection.Options) ([]detection.DeviceInfo, error) {
+		return []detection.DeviceInfo{
+			{Name: "I2CBus", Path: "/dev/i2c-1", Transport: "i2c"},
+			{Name: "SPIBus", Path: "/dev/spidev0.0", Transport: "spi"},
+			{Name: "UARTDev", Path: "/dev/ttyUSB0", Transport: "uart"},
+		}, nil
+	}
+
+	device, err := ConnectDevice(context.Background(), "",
+		WithAutoDetection(),
+		WithTransportFromDeviceFactory(deviceFactory),
+		WithDeviceDetector(mockDetector))
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	defer func() {
+		_ = device.Close()
+	}()
+
+	require.NotEmpty(t, createdTransports,
+		"factory must be called at least once")
+	assert.Equal(t, "uart", createdTransports[0],
+		"UART must be tried first even though the detector returned it last; "+
+			"if an I2C transport is ever constructed, periph.io's host.Init() "+
+			"will log a gpiochip permission warning on desktop Linux")
+	assert.Len(t, createdTransports, 1,
+		"UART succeeded on first try, so neither SPI nor I2C transports "+
+			"should have been constructed at all")
+}
+
+// TestSortCandidatesByTransportPreference locks the per-transport-kind
+// ordering as a unit: UART < SPI < I2C, with unknown transports sorting
+// last and stable ordering preserved within each group.
+func TestSortCandidatesByTransportPreference(t *testing.T) {
+	t.Parallel()
+
+	devices := []detection.DeviceInfo{
+		{Name: "i2c-first", Transport: "i2c"},
+		{Name: "bogus-kind", Transport: "usb"},
+		{Name: "spi-middle", Transport: "spi"},
+		{Name: "uart-A", Transport: "uart"},
+		{Name: "i2c-second", Transport: "i2c"},
+		{Name: "uart-B", Transport: "UART"}, // case-insensitive match
+	}
+
+	sortCandidatesByTransportPreference(devices)
+
+	names := make([]string, len(devices))
+	for i, d := range devices {
+		names[i] = d.Name
+	}
+
+	// UART group first (stable: A then B), then SPI, then I2C (stable:
+	// first then second), then any unknown kind.
+	assert.Equal(t,
+		[]string{"uart-A", "uart-B", "spi-middle", "i2c-first", "i2c-second", "bogus-kind"},
+		names)
+}


### PR DESCRIPTION
## Summary

`ConnectDevice`'s auto-detect path picked `devices[0]` from whatever order the parallel detectors returned, handed it to the transport factory, and committed to that single attempt. If the first candidate was an empty I2C bus, the SAM configuration failure in `setupDevice` killed the entire connection attempt — even when a perfectly good UART port had also been detected.

Real-world symptom: on a host where the only PN532 is on UART, `cmd/reader -write "..."` crashed with:

```
2026/04/11 15:25:49 opening gpio chip /dev/gpiochip0 failed. error: open /dev/gpiochip0: permission denied
Error: failed to connect to PN532 device: failed to initialize device: SAM configuration failed:
SAM configuration command failed: failed to send I2C frame: sysfs-i2c: input/output error
```

The `gpiochip0` line is `periph.io`'s `gpioioctl` driver logging during `host.Init()`, which every I2C (and SPI) transport calls on `New()`. The connection failure is the real bug — the warning is just the noise that made it obvious something was wrong.

## Changes

Refactor the auto-detect path so detection results are treated as candidates, not as the answer:

- Split `ConnectDevice` into `connectManual` (explicit path + retry loop) and `connectAutoDetected` (iterate detected candidates).
- `connectAutoDetected` loops over every detected device, calling a new `tryAutoDetectedCandidate` helper that creates the transport, runs `setupDevice`, and **closes the transport on failure** so nothing leaks. The first success is returned immediately.
- Per-candidate failures go to the session log via `Debugf` — not propagated to the caller. Only if **every** candidate fails do we surface an aggregated error naming the total candidate count and joining each per-candidate reason with `errors.Join`.
- `runAutoDetection` extracts the detector-dispatch-and-normalise logic out of the iteration loop so "no devices found" stays a distinct, clean error.
- `setupDeviceWithRetry`'s `autoDetect` short-circuit is removed. Only `connectManual` calls it now; each auto-detect candidate gets exactly one SAM attempt inside `tryAutoDetectedCandidate`, which preserves the existing \"auto-detection bypasses retry logic\" contract while still allowing fallback across candidates.

**Candidate ordering** (second commit): before iterating, stable-sort the detected devices so UART comes before SPI comes before I2C. The reason is narrowly practical — `host.Init()` is only called when the library actually constructs an I2C or SPI transport, and on desktop Linux that call emits a `/dev/gpiochip0` permission-denied warning from `gpioioctl` for any user who isn't in the `gpio` group. With UART tried first, a working UART PN532 makes us return before `i2c.New()` ever runs, so the warning stays silent in the common case. This is **not** a confidence sort — any working candidate still wins — it's a transport-kind preference aimed at killing the periph.io noise.

### What this does not do

- **No confidence sorting inside a transport kind**. Order within a group (multiple UART candidates, multiple I2C candidates) is preserved from whatever the detector returned.
- **No filtering of which transports to probe**. The library stays neutral; `cmd/reader` still registers all three detectors via blank imports. A `--transports` flag is still a reasonable follow-up for users who want to skip I2C/SPI entirely, but it isn't needed once UART-first ordering lands.
- **Does not silence periph.io's log** directly. We avoid it by not calling `host.Init()` in the common path; if the user has no UART PN532 and we do fall through to I2C/SPI, the warning still appears. That's a separate, narrower problem.

## Test plan

- [x] `make test` — full suite passes with race detection
- [x] `make lint` — 0 issues
- [x] `make check` — full pre-commit check passes
- [x] **`TestConnectDevice_AutoDetect_FallsBackOnInitFailure`**: two candidates, first returns a SAM-config-failing transport, second returns a working one. Asserts the working device is returned, both factories were called, the failing transport is closed, and the working transport is still open.
- [x] **`TestConnectDevice_AutoDetect_AggregatesWhenAllFail`**: two failing candidates. Asserts the error contains `\"all 2 auto-detected candidate(s) failed\"`, both candidates were tried, and both transports are closed.
- [x] **`TestConnectDevice_AutoDetect_PrefersUARTOverI2C`**: detector returns `{i2c, spi, uart}` in that order, working UART mock is last. Asserts the factory is called exactly once and only for the UART candidate — neither the I2C nor the SPI transport is ever constructed.
- [x] **`TestSortCandidatesByTransportPreference`**: unit test locking in `uart < spi < i2c < unknown` and stable ordering within each group (case-insensitive match on the Transport field).
- [x] Existing `TestConnectDevice_WithConnectionRetries` (manual path + retry, auto-detect bypasses retry) still passes unchanged — auto-detect still gets exactly one SAM attempt per candidate.
- [x] Manual validation with `go run cmd/reader -write "..."` on a host with 22 empty I2C buses + 1 UART PN532: UART is tried first and succeeds; no I2C transport is ever constructed and the gpiochip warning no longer appears in the debug log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Split connection flows into manual vs auto-detection with prioritized transport ordering (UART → SPI → I2C), consolidated aggregated errors when all candidates fail, and clearer error messages including attempted paths; failed transports are closed promptly. Retry behavior applies only to manual connections.

* **Tests**
  * Added tests covering auto-detection candidate iteration, transport preference ordering, error aggregation, and proper transport open/close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->