### PR TITLE
feat(detection): parallel I2C bus probing in Safe/Full modes

### DIFF
--- a/detection/i2c/detect_linux.go
+++ b/detection/i2c/detect_linux.go
@@ -61,10 +61,11 @@ func detectLinux(ctx context.Context, opts *detection.Options) ([]detection.Devi
 		devices = buildPassiveDevices(filtered)
 	}
 
+	if ctx.Err() != nil {
+		return devices, detection.ErrDetectionTimeout
+	}
+
 	if len(devices) == 0 {
-		if ctx.Err() != nil {
-			return nil, detection.ErrDetectionTimeout
-		}
 		return nil, detection.ErrNoDevicesFound
 	}
 
@@ -91,16 +92,24 @@ func buildPassiveDevices(buses []i2cBusInfo) []detection.DeviceInfo {
 	return devices
 }
 
+// probeResult pairs a successful probe with its original bus index so results
+// can be returned in discovery order regardless of goroutine completion order.
+type probeResult struct {
+	info  detection.DeviceInfo
+	index int
+}
+
 // probeI2CBuses probes each bus in parallel and returns only confirmed devices.
+// Results are returned in the same order as the input buses slice.
 // Context cancellation is best-effort: the initial transport open does not accept
 // a context, so goroutines may block on kernel I2C setup until it completes.
 func probeI2CBuses(ctx context.Context, buses []i2cBusInfo, mode detection.Mode) []detection.DeviceInfo {
-	results := make(chan detection.DeviceInfo, len(buses))
+	results := make(chan probeResult, len(buses))
 
 	var wg sync.WaitGroup
-	for _, bus := range buses {
+	for idx, bus := range buses {
 		wg.Add(1)
-		go func(busPath string) {
+		go func(index int, busPath string) {
 			defer wg.Done()
 
 			select {
@@ -111,11 +120,11 @@ func probeI2CBuses(ctx context.Context, buses []i2cBusInfo, mode detection.Mode)
 
 			if probeDeviceFn(ctx, busPath, mode) {
 				pn532.Debugf("i2c: probe succeeded on %s", busPath)
-				results <- makeDeviceInfo(busPath, detection.High)
+				results <- probeResult{index: index, info: makeDeviceInfo(busPath, detection.High)}
 			} else {
 				pn532.Debugf("i2c: probe failed on %s, skipping", busPath)
 			}
-		}(bus.Path)
+		}(idx, bus.Path)
 	}
 
 	go func() {
@@ -123,9 +132,19 @@ func probeI2CBuses(ctx context.Context, buses []i2cBusInfo, mode detection.Mode)
 		close(results)
 	}()
 
-	var devices []detection.DeviceInfo
-	for device := range results {
-		devices = append(devices, device)
+	// Collect results into index-keyed slots, then compact to preserve bus order.
+	slots := make([]detection.DeviceInfo, len(buses))
+	found := make([]bool, len(buses))
+	for result := range results {
+		slots[result.index] = result.info
+		found[result.index] = true
+	}
+
+	devices := make([]detection.DeviceInfo, 0, len(buses))
+	for idx, ok := range found {
+		if ok {
+			devices = append(devices, slots[idx])
+		}
 	}
 	return devices
 }

--- a/detection/i2c/detect_linux.go
+++ b/detection/i2c/detect_linux.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"unsafe"
 
+	pn532 "github.com/ZaparooProject/go-pn532"
 	"github.com/ZaparooProject/go-pn532/detection"
+	i2ctransport "github.com/ZaparooProject/go-pn532/transport/i2c"
 )
 
 const (
@@ -24,11 +27,20 @@ type i2cBusInfo struct {
 	Number int
 }
 
+// probeDeviceFn is the function used to probe I2C devices during detection.
+// Defaults to probeDeviceImpl; overridden in tests.
+var probeDeviceFn = probeDeviceImpl
+
+// findI2CBusesFn is the function used to enumerate I2C buses.
+// Defaults to findI2CBuses; overridden in tests.
+var findI2CBusesFn = findI2CBuses
+
 // detectLinux searches for PN532 devices on Linux I2C buses.
-// Only probes the known PN532 address (0x24) on each bus — does NOT scan
-// all addresses, which is slow and risks locking devices on designware controllers.
+// In Passive mode, returns all valid buses as Low confidence candidates.
+// In Safe/Full modes, probes each bus in parallel and returns only confirmed
+// devices as High confidence candidates.
 func detectLinux(ctx context.Context, opts *detection.Options) ([]detection.DeviceInfo, error) {
-	buses, err := findI2CBuses()
+	buses, err := findI2CBusesFn()
 	if err != nil {
 		return nil, err
 	}
@@ -37,42 +49,129 @@ func detectLinux(ctx context.Context, opts *detection.Options) ([]detection.Devi
 		return nil, detection.ErrNoDevicesFound
 	}
 
+	filtered := filterBusesByIgnorePaths(buses, opts.IgnorePaths)
+	if len(filtered) == 0 {
+		return nil, detection.ErrNoDevicesFound
+	}
+
 	var devices []detection.DeviceInfo
-
-	for _, bus := range buses {
-		select {
-		case <-ctx.Done():
-			return devices, detection.ErrDetectionTimeout
-		default:
-		}
-
-		busPath := bus.Path
-
-		if detection.IsPathIgnored(busPath, opts.IgnorePaths) {
-			continue
-		}
-
-		// Return every valid I2C bus as a candidate with Low confidence.
-		// Actual PN532 confirmation happens when the transport opens and
-		// sends SAMConfiguration — probing here risks bus contention with
-		// the designware I2C controller.
-		devices = append(devices, detection.DeviceInfo{
-			Transport:  "i2c",
-			Path:       busPath,
-			Name:       fmt.Sprintf("I2C bus %s", busPath),
-			Confidence: detection.Low,
-			Metadata: map[string]string{
-				"bus":     busPath,
-				"address": fmt.Sprintf("0x%02X", DefaultPN532Address),
-			},
-		})
+	if opts.Mode >= detection.Safe {
+		devices = probeI2CBuses(ctx, filtered, opts.Mode)
+	} else {
+		devices = buildPassiveDevices(filtered)
 	}
 
 	if len(devices) == 0 {
+		if ctx.Err() != nil {
+			return nil, detection.ErrDetectionTimeout
+		}
 		return nil, detection.ErrNoDevicesFound
 	}
 
 	return devices, nil
+}
+
+// filterBusesByIgnorePaths removes buses whose paths are in the ignore list.
+func filterBusesByIgnorePaths(buses []i2cBusInfo, ignorePaths []string) []i2cBusInfo {
+	filtered := make([]i2cBusInfo, 0, len(buses))
+	for _, bus := range buses {
+		if !detection.IsPathIgnored(bus.Path, ignorePaths) {
+			filtered = append(filtered, bus)
+		}
+	}
+	return filtered
+}
+
+// buildPassiveDevices returns all buses as Low confidence candidates without probing.
+func buildPassiveDevices(buses []i2cBusInfo) []detection.DeviceInfo {
+	devices := make([]detection.DeviceInfo, 0, len(buses))
+	for _, bus := range buses {
+		devices = append(devices, makeDeviceInfo(bus.Path, detection.Low))
+	}
+	return devices
+}
+
+// probeI2CBuses probes each bus in parallel and returns only confirmed devices.
+// Context cancellation is best-effort: the initial transport open does not accept
+// a context, so goroutines may block on kernel I2C setup until it completes.
+func probeI2CBuses(ctx context.Context, buses []i2cBusInfo, mode detection.Mode) []detection.DeviceInfo {
+	results := make(chan detection.DeviceInfo, len(buses))
+
+	var wg sync.WaitGroup
+	for _, bus := range buses {
+		wg.Add(1)
+		go func(busPath string) {
+			defer wg.Done()
+
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			if probeDeviceFn(ctx, busPath, mode) {
+				pn532.Debugf("i2c: probe succeeded on %s", busPath)
+				results <- makeDeviceInfo(busPath, detection.High)
+			} else {
+				pn532.Debugf("i2c: probe failed on %s, skipping", busPath)
+			}
+		}(bus.Path)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var devices []detection.DeviceInfo
+	for device := range results {
+		devices = append(devices, device)
+	}
+	return devices
+}
+
+// makeDeviceInfo builds a DeviceInfo for an I2C bus.
+func makeDeviceInfo(busPath string, confidence detection.Confidence) detection.DeviceInfo {
+	return detection.DeviceInfo{
+		Transport:  "i2c",
+		Path:       busPath,
+		Name:       fmt.Sprintf("I2C bus %s", busPath),
+		Confidence: confidence,
+		Metadata: map[string]string{
+			"bus":     busPath,
+			"address": fmt.Sprintf("0x%02X", DefaultPN532Address),
+		},
+	}
+}
+
+// probeDeviceImpl attempts to communicate with a device to verify it's a PN532.
+//
+// NO RETRY POLICY: This function intentionally performs only a single attempt.
+// Connection retries are handled at the device level for known PN532 paths,
+// not during auto-detection.
+func probeDeviceImpl(ctx context.Context, busPath string, mode detection.Mode) bool {
+	transport, err := i2ctransport.New(busPath)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = transport.Close() }()
+
+	device, err := pn532.New(transport)
+	if err != nil {
+		return false
+	}
+
+	switch mode {
+	case detection.Safe:
+		_, err = device.GetFirmwareVersion(ctx)
+		return err == nil
+	case detection.Full:
+		return device.Init(ctx) == nil
+	case detection.Passive:
+		return false
+	}
+
+	return false
 }
 
 // findI2CBuses discovers available I2C buses on the system.

--- a/detection/i2c/detect_linux_test.go
+++ b/detection/i2c/detect_linux_test.go
@@ -162,6 +162,31 @@ func TestDetectLinux_SafeMode_ContextCancellation(t *testing.T) {
 		"should return promptly after context cancellation")
 }
 
+func TestDetectLinux_SafeMode_ContextCancellation_ReturnsPartialResults(t *testing.T) {
+	saveFns(t)
+
+	// Bus 0 succeeds immediately, buses 1-2 block until context cancels.
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2")
+	probeDeviceFn = func(ctx context.Context, path string, _ detection.Mode) bool {
+		if path == "/dev/i2c-0" {
+			return true
+		}
+		<-ctx.Done()
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	opts := &detection.Options{Mode: detection.Safe}
+	devices, err := detectLinux(ctx, opts)
+
+	require.ErrorIs(t, err, detection.ErrDetectionTimeout)
+	require.Len(t, devices, 1, "must return the one successful probe as partial results")
+	assert.Equal(t, "/dev/i2c-0", devices[0].Path)
+	assert.Equal(t, detection.High, devices[0].Confidence)
+}
+
 func TestDetectLinux_SafeMode_AllProbesFail_ReturnsError(t *testing.T) {
 	saveFns(t)
 

--- a/detection/i2c/detect_linux_test.go
+++ b/detection/i2c/detect_linux_test.go
@@ -1,0 +1,204 @@
+//go:build linux
+
+//nolint:paralleltest // Tests mutate package-level probeDeviceFn and findI2CBusesFn
+package i2c
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ZaparooProject/go-pn532/detection"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// saveFns saves the package-level test hooks and registers a cleanup to restore them.
+func saveFns(t *testing.T) {
+	t.Helper()
+	origProbe := probeDeviceFn
+	origFind := findI2CBusesFn
+	t.Cleanup(func() {
+		probeDeviceFn = origProbe
+		findI2CBusesFn = origFind
+	})
+}
+
+func fakeBuses(paths ...string) func() ([]i2cBusInfo, error) {
+	return func() ([]i2cBusInfo, error) {
+		buses := make([]i2cBusInfo, len(paths))
+		for idx, path := range paths {
+			buses[idx] = i2cBusInfo{Path: path, Number: idx}
+		}
+		return buses, nil
+	}
+}
+
+func TestDetectLinux_PassiveMode_ReturnsAllBusesWithoutProbing(t *testing.T) {
+	saveFns(t)
+
+	var probeCalled atomic.Bool
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2")
+	probeDeviceFn = func(context.Context, string, detection.Mode) bool {
+		probeCalled.Store(true)
+		return false
+	}
+
+	opts := &detection.Options{Mode: detection.Passive}
+	devices, err := detectLinux(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Len(t, devices, 3)
+	for _, device := range devices {
+		assert.Equal(t, detection.Low, device.Confidence)
+	}
+	assert.False(t, probeCalled.Load(), "probe must not be called in Passive mode")
+}
+
+func TestDetectLinux_PassiveMode_IgnorePathsRespected(t *testing.T) {
+	saveFns(t)
+
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2")
+	probeDeviceFn = func(context.Context, string, detection.Mode) bool {
+		return false
+	}
+
+	opts := &detection.Options{
+		Mode:        detection.Passive,
+		IgnorePaths: []string{"/dev/i2c-1"},
+	}
+	devices, err := detectLinux(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Len(t, devices, 2)
+	for _, device := range devices {
+		assert.NotEqual(t, "/dev/i2c-1", device.Path)
+	}
+}
+
+func TestDetectLinux_SafeMode_OnlyReturnsSuccessfulProbes(t *testing.T) {
+	saveFns(t)
+
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2")
+	probeDeviceFn = func(_ context.Context, path string, _ detection.Mode) bool {
+		return path == "/dev/i2c-1"
+	}
+
+	opts := &detection.Options{Mode: detection.Safe}
+	devices, err := detectLinux(context.Background(), opts)
+	require.NoError(t, err)
+	require.Len(t, devices, 1)
+	assert.Equal(t, "/dev/i2c-1", devices[0].Path)
+	assert.Equal(t, detection.High, devices[0].Confidence)
+}
+
+func TestDetectLinux_SafeMode_ProbesInParallel(t *testing.T) {
+	saveFns(t)
+
+	const busCount = 5
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2", "/dev/i2c-3", "/dev/i2c-4")
+
+	// Barrier: all probes must arrive before any can return.
+	// If probes run sequentially, the first blocks forever waiting for the
+	// rest — the test timeout catches that.
+	var arrived atomic.Int32
+	gate := make(chan struct{})
+	probeDeviceFn = func(_ context.Context, _ string, _ detection.Mode) bool {
+		if arrived.Add(1) == int32(busCount) {
+			close(gate)
+		}
+		<-gate
+		return true
+	}
+
+	opts := &detection.Options{Mode: detection.Safe}
+	devices, err := detectLinux(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Len(t, devices, busCount)
+}
+
+func TestDetectLinux_SafeMode_IgnorePathsRespected(t *testing.T) {
+	saveFns(t)
+
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2")
+	var probeCount atomic.Int32
+	probeDeviceFn = func(_ context.Context, _ string, _ detection.Mode) bool {
+		probeCount.Add(1)
+		return true
+	}
+
+	opts := &detection.Options{
+		Mode:        detection.Safe,
+		IgnorePaths: []string{"/dev/i2c-1"},
+	}
+	devices, err := detectLinux(context.Background(), opts)
+	require.NoError(t, err)
+	assert.Len(t, devices, 2)
+	assert.Equal(t, int32(2), probeCount.Load(), "ignored bus must not be probed")
+
+	for _, device := range devices {
+		assert.NotEqual(t, "/dev/i2c-1", device.Path)
+	}
+}
+
+func TestDetectLinux_SafeMode_ContextCancellation(t *testing.T) {
+	saveFns(t)
+
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2", "/dev/i2c-3", "/dev/i2c-4")
+	probeDeviceFn = func(ctx context.Context, _ string, _ detection.Mode) bool {
+		<-ctx.Done()
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	opts := &detection.Options{Mode: detection.Safe}
+	start := time.Now()
+	_, err := detectLinux(ctx, opts)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, detection.ErrDetectionTimeout)
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"should return promptly after context cancellation")
+}
+
+func TestDetectLinux_SafeMode_AllProbesFail_ReturnsError(t *testing.T) {
+	saveFns(t)
+
+	findI2CBusesFn = fakeBuses("/dev/i2c-0", "/dev/i2c-1", "/dev/i2c-2")
+	probeDeviceFn = func(context.Context, string, detection.Mode) bool {
+		return false
+	}
+
+	opts := &detection.Options{Mode: detection.Safe}
+	_, err := detectLinux(context.Background(), opts)
+	assert.ErrorIs(t, err, detection.ErrNoDevicesFound)
+}
+
+func TestDetectLinux_FullMode_ProbesDevices(t *testing.T) {
+	saveFns(t)
+
+	findI2CBusesFn = fakeBuses("/dev/i2c-0")
+	var receivedMode detection.Mode
+	probeDeviceFn = func(_ context.Context, _ string, mode detection.Mode) bool {
+		receivedMode = mode
+		return true
+	}
+
+	opts := &detection.Options{Mode: detection.Full}
+	devices, err := detectLinux(context.Background(), opts)
+	require.NoError(t, err)
+	require.Len(t, devices, 1)
+	assert.Equal(t, detection.High, devices[0].Confidence)
+	assert.Equal(t, detection.Full, receivedMode)
+}
+
+func TestDetectLinux_NoBuses_ReturnsError(t *testing.T) {
+	saveFns(t)
+
+	findI2CBusesFn = fakeBuses()
+
+	opts := &detection.Options{Mode: detection.Safe}
+	_, err := detectLinux(context.Background(), opts)
+	assert.ErrorIs(t, err, detection.ErrNoDevicesFound)
+}


### PR DESCRIPTION
## Summary

- In Safe/Full detection modes, probe address 0x24 on each I2C bus in parallel using `GetFirmwareVersion`. Only confirmed buses are returned as High confidence candidates. Passive mode keeps the existing behavior (all valid buses returned as Low confidence).
- Kernel I2C reads on designware controllers block ~7s per bus. Parallel probing overlaps these kernel-level blocks so total time is ~7s regardless of bus count, vs ~7s×N sequential.
- Adds 9 tests covering both modes, parallel execution (barrier-based, no timing flakiness), IgnorePaths filtering, context cancellation, and error paths.

## Test plan

- [x] `make check` passes (lint + test + deadlock detection)
- [x] All 9 new I2C detection tests pass with `-race`
- [x] Parallelism test uses deterministic barrier pattern (no wall-clock assertions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bus path filtering to exclude specific I2C devices.
  * Parallel probing for faster detection.
  * Mode-aware detection: passive mode lists candidates without probing; safe/full modes probe to confirm devices.
  * Timeout handling that returns promptly and can yield partial results on cancellation.

* **Bug Fixes**
  * More accurate confidence-level reporting and clearer "no devices" errors.

* **Tests**
  * Added Linux unit tests covering modes, filtering, concurrency, timeouts, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->