### PR TITLE
fix(detection): make bus auto-detect opt-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ tmp/
 
 .agent-shell/
 .claude/
+.opencode/
 .serena/
 CLAUDE.md
 

--- a/detection/detector.go
+++ b/detection/detector.go
@@ -26,6 +26,16 @@ import (
 type Mode int
 
 const (
+	// TransportUART identifies UART/serial PN532 detection.
+	TransportUART = "uart"
+	// TransportSPI identifies SPI PN532 detection.
+	TransportSPI = "spi"
+	// TransportI2C identifies I2C PN532 detection. I2C probing can be unsafe on
+	// some platforms, so it is not part of the default auto-detect transports.
+	TransportI2C = "i2c"
+)
+
+const (
 	// Passive mode only checks device descriptors without any communication
 	Passive Mode = iota
 	// Safe mode performs minimal probing with GetFirmwareVersion command
@@ -80,7 +90,8 @@ type Options struct {
 	Blocklist []string
 	// Device paths to explicitly ignore (e.g., ["/dev/ttyUSB0", "COM2"])
 	IgnorePaths []string
-	// Which transports to check (empty = all)
+	// Which transports to check. Empty means the safe default, UART only;
+	// include TransportSPI or TransportI2C explicitly to opt into bus probing.
 	Transports []string
 	// Cache TTL duration
 	CacheTTL time.Duration
@@ -92,12 +103,20 @@ type Options struct {
 	EnableCache bool
 }
 
-// DefaultOptions returns sensible default detection options
+// DefaultTransports returns the safe default transports used for auto-detect.
+// SPI and I2C are intentionally excluded because probing shared buses may be
+// unsafe on some platforms; include them explicitly when bus detection is wanted.
+func DefaultTransports() []string {
+	return []string{TransportUART}
+}
+
+// DefaultOptions returns sensible default detection options.
 func DefaultOptions() Options {
 	return Options{
 		Mode:        Safe,
 		Timeout:     5 * time.Second,
 		Blocklist:   DefaultBlocklist(),
+		Transports:  DefaultTransports(),
 		EnableCache: true,
 		CacheTTL:    30 * time.Second,
 	}
@@ -132,7 +151,7 @@ func RegisterDetector(d Detector) {
 // getDetectors returns detectors filtered by transport types
 func getDetectors(transports []string) []Detector {
 	if len(transports) == 0 {
-		return registry
+		transports = DefaultTransports()
 	}
 
 	var filtered []Detector

--- a/detection/detector_test.go
+++ b/detection/detector_test.go
@@ -3,6 +3,7 @@ package detection
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -96,6 +97,14 @@ func TestDefaultOptions(t *testing.T) {
 	assert.True(t, opts.EnableCache)
 	assert.Equal(t, 30*time.Second, opts.CacheTTL)
 	assert.NotNil(t, opts.Blocklist)
+	assert.Equal(t, []string{TransportUART}, opts.Transports)
+	assert.NotContains(t, opts.Transports, TransportSPI)
+	assert.NotContains(t, opts.Transports, TransportI2C)
+
+	transports := opts.Transports
+	transports[0] = TransportI2C
+	assert.Equal(t, []string{TransportUART}, DefaultOptions().Transports,
+		"DefaultOptions must return an independent transports slice")
 }
 
 // --- Cache Tests ---
@@ -321,6 +330,14 @@ func (m *MockDetector) Transport() string {
 	return m.transport
 }
 
+func detectorTransports(detectors []Detector) []string {
+	transports := make([]string, 0, len(detectors))
+	for _, detector := range detectors {
+		transports = append(transports, detector.Transport())
+	}
+	return transports
+}
+
 func TestGetDetectors_FilterByTransport(t *testing.T) {
 	// Save and restore original registry
 	originalRegistry := registry
@@ -328,28 +345,102 @@ func TestGetDetectors_FilterByTransport(t *testing.T) {
 
 	// Clear and setup test registry
 	registry = nil
-	RegisterDetector(&MockDetector{transport: "uart"})
-	RegisterDetector(&MockDetector{transport: "i2c"})
-	RegisterDetector(&MockDetector{transport: "spi"})
+	RegisterDetector(&MockDetector{transport: TransportUART})
+	RegisterDetector(&MockDetector{transport: TransportI2C})
+	RegisterDetector(&MockDetector{transport: TransportSPI})
 
 	tests := []struct {
 		name       string
 		transports []string
-		expected   int
+		expected   []string
 	}{
-		{"All transports", nil, 3},
-		{"Empty transports", []string{}, 3},
-		{"Single transport", []string{"uart"}, 1},
-		{"Two transports", []string{"uart", "i2c"}, 2},
-		{"Non-existent transport", []string{"usb"}, 0},
+		{"Default transports from nil", nil, []string{TransportUART}},
+		{"Default transports from empty", []string{}, []string{TransportUART}},
+		{"Single transport", []string{TransportUART}, []string{TransportUART}},
+		{"Explicit SPI opt-in", []string{TransportSPI}, []string{TransportSPI}},
+		{"Explicit I2C opt-in", []string{TransportI2C}, []string{TransportI2C}},
+		{
+			"Explicit all transports",
+			[]string{TransportUART, TransportSPI, TransportI2C},
+			[]string{TransportUART, TransportI2C, TransportSPI},
+		},
+		{"Non-existent transport", []string{"usb"}, []string{}},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := getDetectors(tc.transports)
-			assert.Len(t, result, tc.expected)
+			assert.Equal(t, tc.expected, detectorTransports(result))
 		})
 	}
+}
+
+type CountingDetector struct {
+	transport string
+	calls     atomic.Int32
+}
+
+func (d *CountingDetector) Detect(_ context.Context, _ *Options) ([]DeviceInfo, error) {
+	d.calls.Add(1)
+	return nil, ErrNoDevicesFound
+}
+
+func (d *CountingDetector) Transport() string {
+	return d.transport
+}
+
+func TestDetectAll_DefaultOnlyInvokesUART(t *testing.T) {
+	originalRegistry := registry
+	defer func() { registry = originalRegistry }()
+
+	uart := &CountingDetector{transport: TransportUART}
+	spi := &CountingDetector{transport: TransportSPI}
+	i2c := &CountingDetector{transport: TransportI2C}
+
+	registry = nil
+	RegisterDetector(uart)
+	RegisterDetector(i2c)
+	RegisterDetector(spi)
+
+	opts := DefaultOptions()
+	opts.EnableCache = false
+
+	_, err := DetectAll(context.Background(), &opts)
+	require.ErrorIs(t, err, ErrNoDevicesFound)
+	assert.Equal(t, int32(1), uart.calls.Load())
+	assert.Equal(t, int32(0), spi.calls.Load())
+	assert.Equal(t, int32(0), i2c.calls.Load())
+}
+
+func TestDetectAll_ExplicitSPIOptIn(t *testing.T) {
+	assertExplicitTransportOptIn(t, TransportSPI)
+}
+
+func TestDetectAll_ExplicitI2COptIn(t *testing.T) {
+	assertExplicitTransportOptIn(t, TransportI2C)
+}
+
+func assertExplicitTransportOptIn(t *testing.T, transport string) {
+	t.Helper()
+
+	originalRegistry := registry
+	defer func() { registry = originalRegistry }()
+
+	uart := &CountingDetector{transport: TransportUART}
+	selected := &CountingDetector{transport: transport}
+
+	registry = nil
+	RegisterDetector(uart)
+	RegisterDetector(selected)
+
+	opts := DefaultOptions()
+	opts.EnableCache = false
+	opts.Transports = []string{transport}
+
+	_, err := DetectAll(context.Background(), &opts)
+	require.ErrorIs(t, err, ErrNoDevicesFound)
+	assert.Equal(t, int32(0), uart.calls.Load())
+	assert.Equal(t, int32(1), selected.calls.Load())
 }
 
 // --- DetectAll Error Cases ---
@@ -382,6 +473,7 @@ func TestDetectAll_Timeout(t *testing.T) {
 	opts := DefaultOptions()
 	opts.Timeout = 10 * time.Millisecond
 	opts.EnableCache = false
+	opts.Transports = []string{"blocking"}
 
 	ctx, cancel := context.WithTimeout(context.Background(), opts.Timeout)
 	defer cancel()

--- a/device.go
+++ b/device.go
@@ -340,11 +340,10 @@ func connectAutoDetected(ctx context.Context, config *connectConfig) (*Device, e
 		return nil, err
 	}
 
-	// Prefer quiet transports first. UART and SPI open cleanly on desktop
-	// Linux; periph.io's host.Init() (called on first I2C/SPI transport
-	// construction) loudly logs a /dev/gpiochip0 permission warning via
-	// gpioioctl whenever the user isn't in the gpio group. If UART is
-	// present we never want to touch that code path, so we try UART
+	// Prefer quiet transports first. periph.io's host.Init() (called on first
+	// I2C/SPI transport construction) loudly logs a /dev/gpiochip0 permission
+	// warning via gpioioctl whenever the user isn't in the gpio group. If UART
+	// is present we never want to touch that code path, so we try UART
 	// candidates before I2C/SPI. This is a transport-kind preference, not
 	// a confidence sort: any working candidate will still win.
 	sortCandidatesByTransportPreference(devices)

--- a/device_test.go
+++ b/device_test.go
@@ -604,13 +604,35 @@ func TestConnectDevice_AutoDetect_AggregatesWhenAllFail(t *testing.T) {
 	assert.False(t, second.IsConnected(), "second failed transport must be closed")
 }
 
+func TestConnectDevice_AutoDetect_UsesSafeDefaultTransports(t *testing.T) {
+	t.Parallel()
+
+	var capturedTransports []string
+	mockDetector := func(_ context.Context, opts *detection.Options) ([]detection.DeviceInfo, error) {
+		capturedTransports = append([]string(nil), opts.Transports...)
+		return nil, detection.ErrNoDevicesFound
+	}
+
+	device, err := ConnectDevice(context.Background(), "",
+		WithAutoDetection(),
+		WithTransportFromDeviceFactory(func(_ detection.DeviceInfo) (Transport, error) {
+			return NewMockTransport(), nil
+		}),
+		WithDeviceDetector(mockDetector))
+	require.Error(t, err)
+	assert.Nil(t, device)
+	assert.Equal(t, []string{detection.TransportUART}, capturedTransports)
+	assert.NotContains(t, capturedTransports, detection.TransportSPI)
+	assert.NotContains(t, capturedTransports, detection.TransportI2C)
+}
+
 // TestConnectDevice_AutoDetect_PrefersUARTOverI2C verifies that when the
 // detector returns a mix of transport types, auto-detection tries UART
-// candidates before I2C (and SPI before I2C) so a working UART PN532
-// succeeds without ever constructing an I2C transport. This matters on
-// Linux desktops where the I2C transport's host.Init() call logs a
-// gpioioctl /dev/gpiochip0 permission warning for users not in the gpio
-// group — we want that warning to stay silent whenever UART works.
+// candidates before I2C/SPI so a working UART PN532 succeeds without ever
+// constructing a bus transport. This matters on Linux desktops where
+// periph.io's host.Init() call logs a gpioioctl /dev/gpiochip0 permission
+// warning for users not in the gpio group — we want that warning to stay
+// silent whenever UART works.
 func TestConnectDevice_AutoDetect_PrefersUARTOverI2C(t *testing.T) {
 	t.Parallel()
 

--- a/docs/dev-acr122u-usb.md
+++ b/docs/dev-acr122u-usb.md
@@ -97,13 +97,18 @@ sudo usermod -a -G plugdev $USER
 The ACR122U detector automatically finds devices via both PC/SC and USB:
 
 ```go
-devices, err := detection.DetectAll(detection.DefaultOptions())
+opts := detection.DefaultOptions()
+devices, err := detection.DetectAll(context.Background(), &opts)
 for _, device := range devices {
     if device.Transport == "acr122u" {
         fmt.Printf("Found: %s (mode: %s)\n", device.Name, device.Metadata["mode"])
     }
 }
 ```
+
+`DefaultOptions` only auto-detects UART by default. To probe shared buses, opt in
+explicitly with `opts.Transports = []string{detection.TransportSPI}` or
+`opts.Transports = []string{detection.TransportI2C}`.
 
 ## Example Usage
 


### PR DESCRIPTION
## Summary
- Make default auto-detection UART-only so shared bus probing is opt-in.
- Add explicit transport constants/defaults and tests for SPI/I2C opt-in behavior.
- Update docs for explicit bus detection and ignore local .opencode state.

## Tests
- make lint
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-detection now defaults to UART transport only, providing a safer default behavior.

* **Documentation**
  * Updated examples to show explicit transport configuration for SPI and I2C detection.
  * Added guidance on how to enable additional transport detection when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->