### PR TITLE
fix: integer overflow in frame extraction and CI fuzz deadline flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,18 @@ jobs:
 
     - name: Run fuzz tests (quick)
       run: |
-        # Run each fuzz test for 10 seconds to catch obvious issues
+        # Budget each fuzz test in executions rather than wall time. A duration
+        # makes the fuzzing engine build a deadline context, and a worker that is
+        # mid-call when it expires reports "context deadline exceeded" as a test
+        # failure. An execution count leaves that context unset, so the run ends
+        # on the limit instead. 1000000x is roughly the previous 10s budget.
         # Corpus files from testdata/fuzz/ are also run as regression tests
-        go test -fuzz=FuzzValidateFrameLength -fuzztime=10s ./internal/frame/
-        go test -fuzz=FuzzValidateFrameChecksum -fuzztime=10s ./internal/frame/
-        go test -fuzz=FuzzExtractFrameData -fuzztime=10s ./internal/frame/
-        go test -fuzz=FuzzHandleErrorFrame -fuzztime=10s ./internal/frame/
-        go test -fuzz=FuzzCalculateChecksum -fuzztime=10s ./internal/frame/
-        go test -fuzz=FuzzBufferPool -fuzztime=10s ./internal/frame/
+        go test -fuzz=FuzzValidateFrameLength -fuzztime=1000000x ./internal/frame/
+        go test -fuzz=FuzzValidateFrameChecksum -fuzztime=1000000x ./internal/frame/
+        go test -fuzz=FuzzExtractFrameData -fuzztime=1000000x ./internal/frame/
+        go test -fuzz=FuzzHandleErrorFrame -fuzztime=1000000x ./internal/frame/
+        go test -fuzz=FuzzCalculateChecksum -fuzztime=1000000x ./internal/frame/
+        go test -fuzz=FuzzBufferPool -fuzztime=1000000x ./internal/frame/
 
   lint:
     needs: changes
@@ -200,9 +204,9 @@ jobs:
       run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.txt
+        files: ./coverage.txt
         flags: unittests
         fail_ci_if_error: false

--- a/internal/frame/extraction.go
+++ b/internal/frame/extraction.go
@@ -42,6 +42,10 @@ const (
 	FrameBufferSize  = 270 // Complete frame with all overhead (262 + 8)
 )
 
+// tfiOffset is the distance from the frame length field to the TFI byte,
+// skipping the length and length-checksum bytes.
+const tfiOffset = 2
+
 // Global buffer pool instance
 var defaultPool = NewBufferPool()
 
@@ -201,10 +205,11 @@ func ExtractFrameData(buf []byte, off, frameLen int, tfiExpected byte) (data []b
 		}
 	}
 
-	// Move to TFI position (skip length and length checksum)
-	off += 2
-
-	if off >= len(buf) {
+	// Move to TFI position (skip length and length checksum).
+	// Compare against the space remaining in buf rather than adding to off
+	// first: a corrupt offset close to the maximum int would wrap negative and
+	// then index buf out of bounds.
+	if off >= len(buf)-tfiOffset {
 		return nil, false, &pn532.TransportError{
 			Op:        "extractFrameData",
 			Err:       pn532.ErrFrameCorrupted,
@@ -212,6 +217,8 @@ func ExtractFrameData(buf []byte, off, frameLen int, tfiExpected byte) (data []b
 			Retryable: true,
 		}
 	}
+
+	off += tfiOffset
 
 	tfi := buf[off]
 
@@ -227,7 +234,13 @@ func ExtractFrameData(buf []byte, off, frameLen int, tfiExpected byte) (data []b
 
 	// Extract frame data (skip TFI)
 	off++
-	if off+frameLen-1 > len(buf) {
+
+	// Bound dataLen by the bytes left in buf. Written as a subtraction so a
+	// corrupt frameLen close to the maximum int cannot overflow the sum and
+	// pass this check, which would size the buffer below from unvalidated
+	// hardware data.
+	dataLen := frameLen - 1
+	if dataLen > len(buf)-off {
 		return nil, false, &pn532.TransportError{
 			Op:        "extractFrameData",
 			Err:       pn532.ErrFrameCorrupted,
@@ -237,7 +250,6 @@ func ExtractFrameData(buf []byte, off, frameLen int, tfiExpected byte) (data []b
 	}
 
 	// Use buffer pool to reduce allocations - this is a major optimization
-	dataLen := frameLen - 1
 	data = GetBuffer(dataLen)
 	copy(data, buf[off:off+dataLen])
 

--- a/internal/frame/extraction_test.go
+++ b/internal/frame/extraction_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frame
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+// TestExtractFrameDataOffsetOverflow covers offsets large enough that stepping
+// to the TFI position would wrap past the maximum int and index buf negatively.
+func TestExtractFrameDataOffsetOverflow(t *testing.T) {
+	t.Parallel()
+	buf := []byte{0x00, 0x00, 0xFF, 0x02, 0xFE, 0xD5, 0x03, 0x28, 0x00}
+
+	for _, off := range []int{math.MaxInt, math.MaxInt - 1, math.MaxInt - 2, len(buf)} {
+		data, retry, err := ExtractFrameData(buf, off, 2, 0xD5)
+		if err == nil {
+			t.Errorf("off=%d: expected error, got data=%v retry=%v", off, data, retry)
+		}
+		if data != nil {
+			t.Errorf("off=%d: expected nil data, got %d bytes", off, len(data))
+		}
+	}
+}
+
+// TestExtractFrameDataLengthOverflow covers frame lengths large enough that the
+// bounds check would wrap past the maximum int, which previously let a corrupt
+// length size the pooled buffer and panic in make.
+func TestExtractFrameDataLengthOverflow(t *testing.T) {
+	t.Parallel()
+	buf := []byte{0x00, 0x00, 0xFF, 0x02, 0xFE, 0xD5, 0x03, 0x28, 0x00}
+
+	for _, frameLen := range []int{math.MaxInt, math.MaxInt - 1, math.MaxInt - 3, 1 << 40, len(buf) + 1} {
+		data, retry, err := ExtractFrameData(buf, 3, frameLen, 0xD5)
+		if err == nil {
+			t.Errorf("frameLen=%d: expected error, got data=%d bytes retry=%v", frameLen, len(data), retry)
+		}
+		if data != nil {
+			t.Errorf("frameLen=%d: expected nil data, got %d bytes", frameLen, len(data))
+		}
+	}
+}
+
+// TestExtractFrameDataValid confirms the tightened bounds checks still accept
+// well-formed frames, including one that fills buf exactly.
+func TestExtractFrameDataValid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		buf      []byte
+		want     []byte
+		off      int
+		frameLen int
+	}{
+		{
+			name:     "minimal frame",
+			buf:      []byte{0x00, 0x00, 0xFF, 0x02, 0xFE, 0xD5, 0x03, 0x28, 0x00},
+			off:      3,
+			frameLen: 2,
+			want:     []byte{0x03},
+		},
+		{
+			name:     "data ends exactly at buffer end",
+			buf:      []byte{0xFF, 0x02, 0xFE, 0xD5, 0x03, 0x28},
+			off:      1,
+			frameLen: 3,
+			want:     []byte{0x03, 0x28},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			data, retry, err := ExtractFrameData(tt.buf, tt.off, tt.frameLen, 0xD5)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if retry {
+				t.Fatal("unexpected retry")
+			}
+			if !bytes.Equal(data, tt.want) {
+				t.Fatalf("got %#x, want %#x", data, tt.want)
+			}
+			PutBuffer(data)
+		})
+	}
+}

--- a/polling/session_test.go
+++ b/polling/session_test.go
@@ -331,6 +331,7 @@ func TestSession_WriteToTag(t *testing.T) {
 		// Create separate contexts - session ctx stays active, write ctx gets cancelled
 		sessionCtx := context.Background()
 		writeCtx, cancelWrite := context.WithCancel(context.Background())
+		defer cancelWrite()
 
 		detectedTag := createTestDetectedTag()
 		writeCalled := false
@@ -360,6 +361,7 @@ func TestSession_WriteToTag(t *testing.T) {
 
 		// Create a context that will be cancelled before the stabilization delay completes
 		writeCtx, cancelWrite := context.WithCancel(context.Background())
+		defer cancelWrite()
 
 		detectedTag := createTestDetectedTag()
 		writeCalled := false
@@ -1000,6 +1002,7 @@ func TestSession_WriteToNextTag(t *testing.T) {
 		// Create separate contexts - session ctx stays active, write ctx gets cancelled
 		sessionCtx := context.Background()
 		writeCtx, cancelWrite := context.WithCancel(context.Background())
+		defer cancelWrite()
 
 		writeCalled := false
 		err := session.WriteToNextTag(

--- a/retry.go
+++ b/retry.go
@@ -71,6 +71,7 @@ func RetryWithConfig(ctx context.Context, config *RetryConfig, retryFunc Retryab
 
 func setupRetryContext(ctx context.Context, config *RetryConfig) (context.Context, context.CancelFunc) {
 	if config.RetryTimeout > 0 {
+		//nolint:gosec // cancel is returned to the caller, which defers it
 		return context.WithTimeout(ctx, config.RetryTimeout)
 	}
 	return ctx, func() {}

--- a/retry.go
+++ b/retry.go
@@ -64,17 +64,13 @@ func RetryWithConfig(ctx context.Context, config *RetryConfig, retryFunc Retryab
 		return retryFunc()
 	}
 
-	retryCtx, cancel := setupRetryContext(ctx, config)
-	defer cancel()
-	return executeWithRetry(retryCtx, config, retryFunc)
-}
-
-func setupRetryContext(ctx context.Context, config *RetryConfig) (context.Context, context.CancelFunc) {
+	retryCtx := ctx
 	if config.RetryTimeout > 0 {
-		//nolint:gosec // cancel is returned to the caller, which defers it
-		return context.WithTimeout(ctx, config.RetryTimeout)
+		var cancel context.CancelFunc
+		retryCtx, cancel = context.WithTimeout(ctx, config.RetryTimeout)
+		defer cancel()
 	}
-	return ctx, func() {}
+	return executeWithRetry(retryCtx, config, retryFunc)
 }
 
 func executeWithRetry(ctx context.Context, config *RetryConfig, retryFunc RetryableFunc) error {

--- a/retry_helpers_test.go
+++ b/retry_helpers_test.go
@@ -100,6 +100,7 @@ func TestWriteNDEFWithRetry_ContextCancelledDuringBackoff(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	var callCount atomic.Int32
 	writeFunc := func(_ context.Context) error {

--- a/robust_test.go
+++ b/robust_test.go
@@ -557,6 +557,7 @@ func TestWriteNDEFWithRetry(t *testing.T) {
 		t.Parallel()
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
 		var attempts int32
 		writeFunc := func(_ context.Context) error {

--- a/transport_context_test.go
+++ b/transport_context_test.go
@@ -168,16 +168,18 @@ type contextTestCase struct {
 }
 
 // createContextForTest creates appropriate context based on test case
-func createContextForTest(tt contextTestCase) (context.Context, context.CancelFunc) {
+func createContextForTest(t *testing.T, tt contextTestCase) context.Context {
+	t.Helper()
 	if tt.contextTimeout == 0 {
 		// Immediate cancellation
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
-		return ctx, cancel
+		return ctx
 	}
 	// Timeout after specified duration
-	//nolint:gosec // cancel is returned to the caller, which defers it
-	return context.WithTimeout(context.Background(), tt.contextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), tt.contextTimeout)
+	t.Cleanup(cancel)
+	return ctx
 }
 
 // validateContextError checks if the error type and timing match expectations
@@ -253,8 +255,7 @@ func TestContextCancellationDuringOperationPhases(t *testing.T) {
 			mock := NewMockTransport()
 			mock.SetDelay(tt.setupDelay)
 
-			ctx, cancel := createContextForTest(tt)
-			defer cancel()
+			ctx := createContextForTest(t, tt)
 
 			cmd := byte(0x02) // GetFirmwareVersion
 			args := []byte{}

--- a/transport_context_test.go
+++ b/transport_context_test.go
@@ -176,6 +176,7 @@ func createContextForTest(tt contextTestCase) (context.Context, context.CancelFu
 		return ctx, cancel
 	}
 	// Timeout after specified duration
+	//nolint:gosec // cancel is returned to the caller, which defers it
 	return context.WithTimeout(context.Background(), tt.contextTimeout)
 }
 


### PR DESCRIPTION
Three unrelated fixes that surfaced while clearing the open dependabot PRs.

## Integer overflow in `ExtractFrameData`

Both bounds checks added a caller-supplied `int` before comparing against `len(buf)`, so a value near `MaxInt` wrapped negative and passed:

- `off += 2` then `off >= len(buf)` wraps to `-9223372036854775807` at `off=MaxInt`, then indexes `buf` negatively.
- `off+frameLen-1 > len(buf)` wraps the same way, letting a corrupt `frameLen` size the pooled buffer. `GetBuffer` falls through to `make([]byte, size)` for oversized requests, which panics with `makeslice: len out of range`.

Reproduced against unfixed code:

```
guard computes off+frameLen-1 = -9223372036854775807 (len(buf)=6) -> passes=true
panic: runtime error: makeslice: len out of range
  frame.(*BufferPool).GetBuffer(..., 0x7ffffffffffffffe) extraction.go:113
  frame.ExtractFrameData(...) extraction.go:241
```

Both guards are now subtractions against the space remaining in `buf`, which cannot overflow. These values arrive from frames read off the wire, where the input validation this function documents is what stands between malformed hardware data and a panic.

Note this is *not* what failed #79 — a local fuzz run of 19M executions never reached it, since random mutation landing within 3 of `MaxInt` is not realistic. It was found while investigating that failure, not by it.

## Fuzz job reporting `context deadline exceeded`

#79 failed with `context deadline exceeded` at 10.08s against `-fuzztime=10s`, after 866k executions with no crasher — it died at the fuzztime boundary, not on a finding.

A duration budget makes the fuzzing engine wrap its context with a deadline (`internal/fuzz/fuzz.go:104-107`). A worker still in an RPC when that deadline fires returns `ctx.Err()`, which surfaces as a failing test rather than a clean stop. Passing the budget as an execution count leaves `opts.Timeout` at zero, so the deadline context is never constructed and the run ends on the limit. Same fuzzing, deterministic budget; `1000000x` is close to the previous 10s at the throughput these targets reach on CI.

## Codecov upload input

The coverage step passed `file:`, which codecov-action v6 and v7 do not accept — runs logged `Unexpected input(s) 'file'` and fell back to searching for a report, with `fail_ci_if_error: false` masking the outcome. The input is `files`.

The pin comment also read `# v6` after the 7.0.0 bump. `fb8b3582` is the `chore(release): 7.0.0` commit, but codecov moved their `v6` and `v6.0.2` tags onto it too, so dependabot resolved the comment to the wrong tag. The pin was already correct; only the comment changes.

## gosec G118

golangci-lint 2.11.2 reports six G118 findings that CI will pick up once its `version: latest` pin catches up. Four were real — the cancel function was only reached inside a conditionally-run callback or goroutine — and get a `defer`. Two in `setupRetryContext` and `createContextForTest` return the cancel function to a caller that defers it; gosec cannot track that across the return, so they are annotated with the reason.

---

`golangci-lint run` reports 0 issues, `actionlint` is clean, `go test -race ./...` passes, and all six fuzz targets pass under the new budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame parsing to reject malformed/oversized inputs safely, preventing out-of-bounds failures.
  * Ensured valid frames are still extracted correctly, including when data ends exactly at the buffer boundary.
  * Applied the configured retry timeout more directly during retry operations.
* **Tests**
  * Added new extraction test coverage for offset/length overflow and valid extraction cases.
  * Improved cancellation cleanup across retry/session-related tests.
* **Chores**
  * Updated fuzz-testing budget and refreshed Codecov upload configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->