### PR TITLE
feat(uart): support PN532Killer readers

### DIFF
--- a/detection/uart/detector.go
+++ b/detection/uart/detector.go
@@ -274,6 +274,7 @@ func isLikelyPN532(port *serialPort) bool {
 		"0403:6001", // FTDI FT232 (common in PN532 boards)
 		"10C4:EA60", // Silicon Labs CP210x (common in PN532 boards)
 		"1A86:7523", // QinHeng CH340 (common in PN532 boards)
+		"1A86:55D3", // PN532Killer CH343 USB UART
 	}
 
 	upperVIDPID := strings.ToUpper(port.VIDPID)

--- a/detection/uart/detector_test.go
+++ b/detection/uart/detector_test.go
@@ -89,3 +89,21 @@ func TestProcessPort_SafeMode_FailedProbeDiscardsUnknownDevice(t *testing.T) {
 	_, included := det.processPort(context.Background(), port, opts)
 	assert.False(t, included, "Safe mode must discard unknown device when probe fails")
 }
+
+func TestPN532KillerIsLikelyAndRetainsMetadata(t *testing.T) {
+	port := &serialPort{
+		Path:         "/dev/ttyACM0",
+		Name:         "ttyACM0",
+		VIDPID:       "1A86:55D3",
+		Manufacturer: "wch.cn",
+		Product:      "PN532Killer-UART",
+		SerialNumber: "00000001",
+	}
+
+	assert.True(t, isLikelyPN532(port))
+
+	device := (&detector{}).createDeviceInfo(port, detection.Medium)
+	assert.Equal(t, "1A86:55D3", device.Metadata["vidpid"])
+	assert.Equal(t, "PN532Killer-UART", device.Metadata["product"])
+	assert.Equal(t, "00000001", device.Metadata["serial"])
+}

--- a/docs/dev-pn532killer-compatibility.md
+++ b/docs/dev-pn532killer-compatibility.md
@@ -33,6 +33,7 @@ PN532Killer Type 2 commands use `InCommunicateThru` with ISO/IEC 14443-A CRC byt
 
 - MIFARE operations continue to use the existing implementation but are not included in the PN532Killer compatibility claim.
 - The observed firmware acknowledges `InSelect` without returning a response and reports framing error `0x05` for `FAST_READ`. The compatibility path preserves selection without `InSelect` and uses standard Type 2 `READ` commands for NDEF data.
+- The observed firmware also reports framing status `0x05` after a successful Type 2 `WRITE` because the tag ACK is four bits. The compatibility path accepts this status only when an immediate page read exactly matches the requested data.
 - Card emulation, traffic sniffing, ISO15693, and PN532Killer-specific extended features are not supported by this integration.
 - There is no firmware-version gate. Compatibility assumes firmware with the same initialization and raw Type 2 behavior as the supported hardware.
 - There is no manual override for incomplete USB metadata. This prevents an unrelated device with the same USB bridge from receiving incompatible serial and tag-command behavior.

--- a/docs/dev-pn532killer-compatibility.md
+++ b/docs/dev-pn532killer-compatibility.md
@@ -22,7 +22,7 @@ The PN532Killer profile opens the port with DTR and RTS deasserted and omits the
 
 - Reader initialization and automatic detection
 - NFC Forum Type 2 and NTAG UID detection
-- NTAG page and fast reads
+- NTAG page reads and NDEF reads with automatic fallback when `FAST_READ` is unavailable
 - NTAG page writes with Type 2 ACK validation
 - NDEF reads and writes on supported NTAG21x tags
 - NTAG version and password-authentication commands
@@ -32,6 +32,7 @@ PN532Killer Type 2 commands use `InCommunicateThru` with ISO/IEC 14443-A CRC byt
 ## Limitations
 
 - MIFARE operations continue to use the existing implementation but are not included in the PN532Killer compatibility claim.
+- The observed firmware acknowledges `InSelect` without returning a response and reports framing error `0x05` for `FAST_READ`. The compatibility path preserves selection without `InSelect` and uses standard Type 2 `READ` commands for NDEF data.
 - Card emulation, traffic sniffing, ISO15693, and PN532Killer-specific extended features are not supported by this integration.
 - There is no firmware-version gate. Compatibility assumes firmware with the same initialization and raw Type 2 behavior as the supported hardware.
 - There is no manual override for incomplete USB metadata. This prevents an unrelated device with the same USB bridge from receiving incompatible serial and tag-command behavior.

--- a/docs/dev-pn532killer-compatibility.md
+++ b/docs/dev-pn532killer-compatibility.md
@@ -1,0 +1,48 @@
+# PN532Killer Compatibility
+
+`go-pn532` supports PN532Killer readers through the existing UART transport. Applications use the normal constructor and do not need a separate driver or configuration option:
+
+```go
+transport, err := uart.New("/dev/ttyACM0")
+```
+
+## Identification
+
+The compatibility profile is selected automatically only when the serial device reports all of the following USB metadata:
+
+- Vendor ID `1A86`
+- Product ID `55D3`
+- Product string `PN532Killer-UART`
+
+Matching is case-insensitive and ignores surrounding whitespace. Serial-device symlinks are resolved before matching. If enumeration fails or any identity field is missing or different, the generic PN532 UART profile is used intentionally.
+
+The PN532Killer profile opens the port with DTR and RTS deasserted. Reconnects reuse the profile selected during the initial open.
+
+## Supported operations
+
+- Reader initialization and automatic detection
+- NFC Forum Type 2 and NTAG UID detection
+- NTAG page and fast reads
+- NTAG page writes with Type 2 ACK validation
+- NDEF reads and writes on supported NTAG21x tags
+- NTAG version and password-authentication commands
+
+PN532Killer Type 2 commands use `InCommunicateThru` with ISO/IEC 14443-A CRC bytes. This is selected through a transport capability, keeping the standard PN532 UART command path unchanged.
+
+## Limitations
+
+- MIFARE operations continue to use the existing implementation but are not included in the PN532Killer compatibility claim.
+- Card emulation, traffic sniffing, ISO15693, and PN532Killer-specific extended features are not supported by this integration.
+- There is no firmware-version gate. Compatibility assumes firmware with the same initialization and raw Type 2 behavior as the supported hardware.
+- There is no manual override for incomplete USB metadata. This prevents an unrelated device with the same USB bridge from receiving incompatible serial and tag-command behavior.
+
+## Troubleshooting
+
+If a reader opens as a generic PN532 or is not detected:
+
+1. Confirm the application is using the device path that belongs to the reader. Persistent `/dev/serial/by-id` symlinks are supported.
+2. Inspect the USB metadata and confirm all three identity fields above are present. On Linux, `udevadm info --query=property --name=/dev/ttyACM0` can show the enumerated vendor, product ID, and product string.
+3. Confirm the process has read/write permission for the serial device.
+4. Disconnect and reconnect the reader after changing permissions or udev rules.
+
+If the metadata differs on otherwise compatible hardware, capture the reported values and firmware details before proposing another identity profile. Do not broaden the existing match to VID/PID alone.

--- a/docs/dev-pn532killer-compatibility.md
+++ b/docs/dev-pn532killer-compatibility.md
@@ -16,7 +16,7 @@ The compatibility profile is selected automatically only when the serial device 
 
 Matching is case-insensitive and ignores surrounding whitespace. Serial-device symlinks are resolved before matching. If enumeration fails or any identity field is missing or different, the generic PN532 UART profile is used intentionally.
 
-The PN532Killer profile opens the port with DTR and RTS deasserted. Reconnects reuse the profile selected during the initial open.
+The PN532Killer profile opens the port with DTR and RTS deasserted and omits the host ACK normally sent after a PN532 response. Reconnects reuse the profile selected during the initial open.
 
 ## Supported operations
 

--- a/ntag.go
+++ b/ntag.go
@@ -226,6 +226,11 @@ func (t *NTAGTag) WriteBlock(ctx context.Context, block uint8, data []byte) erro
 	if t.requiresRawType2Commands() {
 		response, err := t.sendRawType2Command(ctx, cmd)
 		if err != nil {
+			// Some raw transports surface the tag's four-bit write ACK as PN532
+			// framing status 0x05. Treat it as ambiguous and require exact readback.
+			if isRawType2WriteFramingError(err) {
+				return t.verifyRawType2WriteAfterFramingError(ctx, block, data, err)
+			}
 			return fmt.Errorf("%w (block %d): %w", ErrTagWriteFailed, block, err)
 		}
 		if len(response) == 0 {

--- a/ntag.go
+++ b/ntag.go
@@ -285,11 +285,12 @@ func (t *NTAGTag) ReadNDEF(ctx context.Context) (*NDEFMessage, error) {
 		return &NDEFMessage{}, nil
 	}
 
-	// Ensure target is selected before reading. This is defensive against any prior
-	// operations that may have used InCommunicateThru (0x42), which doesn't maintain
-	// the PN532's target selection state. See PN532 User Manual §7.3.9.
-	if err := t.device.InSelect(ctx); err != nil {
-		Debugln("NTAG ReadNDEF: InSelect failed, continuing anyway:", err)
+	// Ensure target is selected before reading on standard transports. Raw Type 2
+	// transports preserve selection themselves and may not return an InSelect response.
+	if !t.requiresRawType2Commands() {
+		if err := t.device.InSelect(ctx); err != nil {
+			Debugln("NTAG ReadNDEF: InSelect failed, continuing anyway:", err)
+		}
 	}
 
 	header, err := t.readNDEFHeader(ctx)
@@ -318,6 +319,11 @@ func (t *NTAGTag) ReadNDEF(ctx context.Context) (*NDEFMessage, error) {
 	// NXP genuine tags have UID prefix 0x04.
 	if len(t.uid) > 0 && t.uid[0] != 0x04 {
 		Debugf("NTAG ReadNDEF: non-NXP UID prefix 0x%02X, skipping FAST_READ for clone compatibility", t.uid[0])
+		return t.readNDEFBlockByBlock(ctx)
+	}
+	// Raw Type 2 transports can reject FAST_READ with a card framing error even
+	// while standard READ works. Prefer the universally supported command for NDEF.
+	if t.requiresRawType2Commands() {
 		return t.readNDEFBlockByBlock(ctx)
 	}
 
@@ -1349,8 +1355,10 @@ func (t *NTAGTag) canAccessPage(ctx context.Context, page uint8) bool {
 		data, err = t.device.SendDataExchange(ctx, []byte{ntagCmdRead, page})
 	}
 	if err != nil {
-		// Re-select target to recover from NAK/timeout errors
-		_ = t.device.InSelect(ctx)
+		// Re-select standard transports to recover from NAK/timeout errors.
+		if !t.requiresRawType2Commands() {
+			_ = t.device.InSelect(ctx)
+		}
 		return false
 	}
 	return len(data) >= 4

--- a/ntag.go
+++ b/ntag.go
@@ -1426,10 +1426,27 @@ func (t *NTAGTag) getTagTypeName() string {
 }
 
 // readBlockWithRetry reads a page through the transport-specific command path
-// and retries standard PN532 exchanges when necessary.
+// and retries short responses or transient RF errors when necessary.
 func (t *NTAGTag) readBlockWithRetry(ctx context.Context, block uint8) ([]byte, error) {
 	if t.requiresRawType2Commands() {
-		return t.readRawType2Pages(ctx, block, ntagBlockSize)
+		var lastErr error
+		for range NTAGBlockReadRetries {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+
+			data, err := t.readRawType2Pages(ctx, block, ntagBlockSize)
+			if err == nil {
+				return data, nil
+			}
+			if !isRetryableRawType2ReadError(err) {
+				return nil, err
+			}
+			lastErr = err
+		}
+
+		return nil, fmt.Errorf("%w (block %d after %d retries): %w",
+			ErrTagReadFailed, block, NTAGBlockReadRetries, lastErr)
 	}
 	for i := range NTAGBlockReadRetries {
 		if err := ctx.Err(); err != nil {

--- a/ntag.go
+++ b/ntag.go
@@ -1425,6 +1425,8 @@ func (t *NTAGTag) getTagTypeName() string {
 	}
 }
 
+// readBlockWithRetry reads a page through the transport-specific command path
+// and retries standard PN532 exchanges when necessary.
 func (t *NTAGTag) readBlockWithRetry(ctx context.Context, block uint8) ([]byte, error) {
 	if t.requiresRawType2Commands() {
 		return t.readRawType2Pages(ctx, block, ntagBlockSize)

--- a/ntag.go
+++ b/ntag.go
@@ -175,6 +175,13 @@ func (t *NTAGTag) ReadBlock(ctx context.Context, block uint8) ([]byte, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if t.requiresRawType2Commands() {
+		data, err := t.readRawType2Pages(ctx, block, ntagBlockSize)
+		if err != nil {
+			return nil, fmt.Errorf("%w (block %d): %w", ErrTagReadFailed, block, err)
+		}
+		return data, nil
+	}
 
 	data, err := t.device.SendDataExchangeWithRetry(ctx, []byte{ntagCmdRead, block})
 	if err != nil {
@@ -216,6 +223,19 @@ func (t *NTAGTag) WriteBlock(ctx context.Context, block uint8, data []byte) erro
 	cmd := make([]byte, 0, 2+len(data))
 	cmd = append(cmd, ntagCmdWrite, block)
 	cmd = append(cmd, data...)
+	if t.requiresRawType2Commands() {
+		response, err := t.sendRawType2Command(ctx, cmd)
+		if err != nil {
+			return fmt.Errorf("%w (block %d): %w", ErrTagWriteFailed, block, err)
+		}
+		if len(response) == 0 {
+			return fmt.Errorf("%w (block %d): missing Type 2 ACK", ErrTagWriteFailed, block)
+		}
+		if response[0]&0x0F != 0x0A {
+			return fmt.Errorf("%w (block %d): Type 2 NAK 0x%02X", ErrTagWriteFailed, block, response[0])
+		}
+		return nil
+	}
 
 	_, err := t.device.SendDataExchangeWithRetry(ctx, cmd)
 	if err != nil {
@@ -397,6 +417,10 @@ func (t *NTAGTag) readRawPages(ctx context.Context, startPage uint8, pageCount i
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	expectedBytes := pageCount * ntagBlockSize
+	if t.requiresRawType2Commands() {
+		return t.readRawType2Pages(ctx, startPage, expectedBytes)
+	}
 
 	// NTAG READ command returns 16 bytes (4 pages) starting from the specified page
 	data, err := t.device.SendDataExchangeWithRetry(ctx, []byte{ntagCmdRead, startPage})
@@ -405,7 +429,6 @@ func (t *NTAGTag) readRawPages(ctx context.Context, startPage uint8, pageCount i
 	}
 
 	// The response should be 16 bytes (4 pages)
-	expectedBytes := pageCount * ntagBlockSize
 	if len(data) < expectedBytes {
 		// Return what we got
 		return data, nil
@@ -873,17 +896,23 @@ func (t *NTAGTag) FastRead(ctx context.Context, startAddr, endAddr uint8) ([]byt
 
 	// Use SendRawCommand for FastRead as some PN532 chips require it
 	// (SendDataExchange returns error 0x81 on some PN532 variants)
-	data, err := t.device.SendRawCommand(ctx, cmd)
+	var data []byte
+	var err error
+	if t.requiresRawType2Commands() {
+		data, err = t.sendRawType2Command(ctx, cmd)
+	} else {
+		data, err = t.device.SendRawCommand(ctx, cmd)
 
-	// Re-select target after SendRawCommand to restore PN532 internal state.
-	// SendRawCommand uses InCommunicateThru (0x42) which is a raw pass-through command
-	// that doesn't maintain the PN532's target selection state. Without re-selection,
-	// subsequent InDataExchange calls may fail with timeout error 01.
-	// See PN532 User Manual §7.3.9: "The host controller has to take care of the
-	// selection of the target it wants to reach (whereas when using the
-	// InDataExchange command, it is done automatically)."
-	if selectErr := t.device.InSelect(ctx); selectErr != nil {
-		Debugln("NTAG FastRead: InSelect after raw command failed:", selectErr)
+		// Re-select target after SendRawCommand to restore PN532 internal state.
+		// SendRawCommand uses InCommunicateThru (0x42) which is a raw pass-through command
+		// that doesn't maintain the PN532's target selection state. Without re-selection,
+		// subsequent InDataExchange calls may fail with timeout error 01.
+		// See PN532 User Manual §7.3.9: "The host controller has to take care of the
+		// selection of the target it wants to reach (whereas when using the
+		// InDataExchange command, it is done automatically)."
+		if selectErr := t.device.InSelect(ctx); selectErr != nil {
+			Debugln("NTAG FastRead: InSelect after raw command failed:", selectErr)
+		}
 	}
 
 	if err != nil {
@@ -918,17 +947,23 @@ func (t *NTAGTag) PwdAuth(ctx context.Context, password []byte) ([]byte, error) 
 	cmd[0] = ntagCmdPwdAuth
 	copy(cmd[1:], password)
 
-	data, err := t.device.SendDataExchange(ctx, cmd)
+	var data []byte
+	var err error
+	if t.requiresRawType2Commands() {
+		data, err = t.sendRawType2Command(ctx, cmd)
+	} else {
+		data, err = t.device.SendDataExchange(ctx, cmd)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("PWD_AUTH failed: %w", err)
 	}
 
 	// Response should be 2-byte PACK
-	if len(data) != 2 {
-		return nil, fmt.Errorf("invalid PACK response length: expected 2 bytes, got %d", len(data))
+	if len(data) < 2 || (!t.requiresRawType2Commands() && len(data) != 2) {
+		return nil, fmt.Errorf("invalid PACK response length: expected at least 2 bytes, got %d", len(data))
 	}
 
-	return data, nil
+	return data[:2], nil
 }
 
 // GetVersion retrieves version information from the NTAG tag using proper GET_VERSION command
@@ -942,7 +977,13 @@ func (t *NTAGTag) GetVersion(ctx context.Context) (*NTAGVersion, error) {
 	// This follows the same pattern as FastRead for better hardware compatibility
 	cmd := []byte{ntagCmdGetVersion}
 
-	data, err := t.device.SendRawCommand(ctx, cmd)
+	var data []byte
+	var err error
+	if t.requiresRawType2Commands() {
+		data, err = t.sendRawType2Command(ctx, cmd)
+	} else {
+		data, err = t.device.SendRawCommand(ctx, cmd)
+	}
 	if err != nil {
 		// If GET_VERSION fails (common with clone devices), fall back to default detection
 		// This maintains backward compatibility while enabling proper detection when possible
@@ -1300,7 +1341,13 @@ func (t *NTAGTag) canAccessPage(ctx context.Context, page uint8) bool {
 	if ctx.Err() != nil {
 		return false
 	}
-	data, err := t.device.SendDataExchange(ctx, []byte{ntagCmdRead, page})
+	var data []byte
+	var err error
+	if t.requiresRawType2Commands() {
+		data, err = t.readRawType2Pages(ctx, page, ntagBlockSize)
+	} else {
+		data, err = t.device.SendDataExchange(ctx, []byte{ntagCmdRead, page})
+	}
 	if err != nil {
 		// Re-select target to recover from NAK/timeout errors
 		_ = t.device.InSelect(ctx)
@@ -1366,6 +1413,9 @@ func (t *NTAGTag) getTagTypeName() string {
 }
 
 func (t *NTAGTag) readBlockWithRetry(ctx context.Context, block uint8) ([]byte, error) {
+	if t.requiresRawType2Commands() {
+		return t.readRawType2Pages(ctx, block, ntagBlockSize)
+	}
 	for i := range NTAGBlockReadRetries {
 		if err := ctx.Err(); err != nil {
 			return nil, err

--- a/ntag.go
+++ b/ntag.go
@@ -907,13 +907,8 @@ func (t *NTAGTag) FastRead(ctx context.Context, startAddr, endAddr uint8) ([]byt
 
 	// Use SendRawCommand for FastRead as some PN532 chips require it
 	// (SendDataExchange returns error 0x81 on some PN532 variants)
-	var data []byte
-	var err error
-	if t.requiresRawType2Commands() {
-		data, err = t.sendRawType2Command(ctx, cmd)
-	} else {
-		data, err = t.device.SendRawCommand(ctx, cmd)
-
+	data, usedRaw, err := t.sendType2Command(ctx, cmd, t.device.SendRawCommand)
+	if !usedRaw {
 		// Re-select target after SendRawCommand to restore PN532 internal state.
 		// SendRawCommand uses InCommunicateThru (0x42) which is a raw pass-through command
 		// that doesn't maintain the PN532's target selection state. Without re-selection,
@@ -958,19 +953,13 @@ func (t *NTAGTag) PwdAuth(ctx context.Context, password []byte) ([]byte, error) 
 	cmd[0] = ntagCmdPwdAuth
 	copy(cmd[1:], password)
 
-	var data []byte
-	var err error
-	if t.requiresRawType2Commands() {
-		data, err = t.sendRawType2Command(ctx, cmd)
-	} else {
-		data, err = t.device.SendDataExchange(ctx, cmd)
-	}
+	data, usedRaw, err := t.sendType2Command(ctx, cmd, t.device.SendDataExchange)
 	if err != nil {
 		return nil, fmt.Errorf("PWD_AUTH failed: %w", err)
 	}
 
 	// Response should be 2-byte PACK
-	if len(data) < 2 || (!t.requiresRawType2Commands() && len(data) != 2) {
+	if len(data) < 2 || (!usedRaw && len(data) != 2) {
 		return nil, fmt.Errorf("invalid PACK response length: expected at least 2 bytes, got %d", len(data))
 	}
 
@@ -988,13 +977,7 @@ func (t *NTAGTag) GetVersion(ctx context.Context) (*NTAGVersion, error) {
 	// This follows the same pattern as FastRead for better hardware compatibility
 	cmd := []byte{ntagCmdGetVersion}
 
-	var data []byte
-	var err error
-	if t.requiresRawType2Commands() {
-		data, err = t.sendRawType2Command(ctx, cmd)
-	} else {
-		data, err = t.device.SendRawCommand(ctx, cmd)
-	}
+	data, _, err := t.sendType2Command(ctx, cmd, t.device.SendRawCommand)
 	if err != nil {
 		// If GET_VERSION fails (common with clone devices), fall back to default detection
 		// This maintains backward compatibility while enabling proper detection when possible

--- a/ntag_raw.go
+++ b/ntag_raw.go
@@ -22,6 +22,10 @@ import (
 	"fmt"
 )
 
+// errRawType2ShortResponse identifies a raw Type 2 response that did not
+// contain the requested payload.
+var errRawType2ShortResponse = errors.New("raw Type 2 response too short")
+
 // requiresRawType2Commands reports whether the transport requires Type 2
 // commands to include CRC-A and use InCommunicateThru.
 func (t *NTAGTag) requiresRawType2Commands() bool {
@@ -64,9 +68,16 @@ func (t *NTAGTag) readRawType2Pages(ctx context.Context, startPage uint8, expect
 		return nil, err
 	}
 	if len(data) < expectedBytes {
-		return nil, fmt.Errorf("invalid raw READ response length %d (expected at least %d)", len(data), expectedBytes)
+		return nil, fmt.Errorf("%w: invalid raw READ response length %d (expected at least %d)",
+			errRawType2ShortResponse, len(data), expectedBytes)
 	}
 	return data[:expectedBytes], nil
+}
+
+// isRetryableRawType2ReadError reports whether a raw Type 2 read failed because
+// of a short response or a transient RF error.
+func isRetryableRawType2ReadError(err error) bool {
+	return errors.Is(err, errRawType2ShortResponse) || isRetryableRFError(err)
 }
 
 // isRawType2WriteFramingError reports whether err is the framing status observed

--- a/ntag_raw.go
+++ b/ntag_raw.go
@@ -16,7 +16,9 @@
 package pn532
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -57,4 +59,27 @@ func (t *NTAGTag) readRawType2Pages(ctx context.Context, startPage uint8, expect
 		return nil, fmt.Errorf("invalid raw READ response length %d (expected at least %d)", len(data), expectedBytes)
 	}
 	return data[:expectedBytes], nil
+}
+
+func isRawType2WriteFramingError(err error) bool {
+	var pn532Err *PN532Error
+	return errors.As(err, &pn532Err) &&
+		pn532Err.Command == "InCommunicateThru" && pn532Err.ErrorCode == 0x05
+}
+
+func (t *NTAGTag) verifyRawType2WriteAfterFramingError(
+	ctx context.Context, block uint8, expected []byte, writeErr error,
+) error {
+	actual, err := t.readRawType2Pages(ctx, block, ntagBlockSize)
+	if err != nil {
+		return fmt.Errorf("%w (block %d): ambiguous Type 2 ACK (%v); verification read failed: %w",
+			ErrTagWriteFailed, block, writeErr, err)
+	}
+	if !bytes.Equal(actual, expected) {
+		return fmt.Errorf("%w (block %d): %w after ambiguous Type 2 ACK: expected %X, got %X",
+			ErrTagWriteFailed, block, ErrWriteVerificationFailed, expected, actual)
+	}
+
+	Debugf("NTAG raw Type 2 write block %d verified after framing status", block)
+	return nil
 }

--- a/ntag_raw.go
+++ b/ntag_raw.go
@@ -22,10 +22,13 @@ import (
 	"fmt"
 )
 
+// requiresRawType2Commands reports whether the transport requires Type 2
+// commands to include CRC-A and use InCommunicateThru.
 func (t *NTAGTag) requiresRawType2Commands() bool {
 	return t.device.hasCapability(CapabilityRequiresRawType2Commands)
 }
 
+// calculateCRCA calculates the ISO/IEC 14443-A CRC and returns it in wire order.
 func calculateCRCA(data []byte) [2]byte {
 	crc := uint16(0x6363)
 	for _, value := range data {
@@ -36,6 +39,7 @@ func calculateCRCA(data []byte) [2]byte {
 	return [2]byte{byte(crc), byte(crc >> 8)}
 }
 
+// appendCRCA returns a copy of data with its CRC-A bytes appended.
 func appendCRCA(data []byte) []byte {
 	command := make([]byte, len(data), len(data)+2)
 	copy(command, data)
@@ -43,6 +47,8 @@ func appendCRCA(data []byte) []byte {
 	return append(command, crc[0], crc[1])
 }
 
+// sendRawType2Command appends CRC-A and sends a Type 2 command through the
+// transport's raw command path.
 func (t *NTAGTag) sendRawType2Command(ctx context.Context, command []byte) ([]byte, error) {
 	// Raw Type 2 transports preserve the active target themselves. Some acknowledge
 	// InSelect without ever returning its response, which stalls and disrupts the
@@ -50,6 +56,8 @@ func (t *NTAGTag) sendRawType2Command(ctx context.Context, command []byte) ([]by
 	return t.device.SendRawCommand(ctx, appendCRCA(command))
 }
 
+// readRawType2Pages reads Type 2 data and removes any bytes beyond the requested
+// payload, including an optional response CRC.
 func (t *NTAGTag) readRawType2Pages(ctx context.Context, startPage uint8, expectedBytes int) ([]byte, error) {
 	data, err := t.sendRawType2Command(ctx, []byte{ntagCmdRead, startPage})
 	if err != nil {
@@ -61,12 +69,16 @@ func (t *NTAGTag) readRawType2Pages(ctx context.Context, startPage uint8, expect
 	return data[:expectedBytes], nil
 }
 
+// isRawType2WriteFramingError reports whether err is the framing status observed
+// when a raw transport receives the four-bit Type 2 write acknowledgment.
 func isRawType2WriteFramingError(err error) bool {
 	var pn532Err *PN532Error
 	return errors.As(err, &pn532Err) &&
 		pn532Err.Command == "InCommunicateThru" && pn532Err.ErrorCode == 0x05
 }
 
+// verifyRawType2WriteAfterFramingError confirms an ambiguous raw write by reading
+// the page back and requiring an exact data match.
 func (t *NTAGTag) verifyRawType2WriteAfterFramingError(
 	ctx context.Context, block uint8, expected []byte, writeErr error,
 ) error {

--- a/ntag_raw.go
+++ b/ntag_raw.go
@@ -1,0 +1,61 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pn532
+
+import (
+	"context"
+	"fmt"
+)
+
+func (t *NTAGTag) requiresRawType2Commands() bool {
+	return t.device.hasCapability(CapabilityRequiresRawType2Commands)
+}
+
+func calculateCRCA(data []byte) [2]byte {
+	crc := uint16(0x6363)
+	for _, value := range data {
+		ch := value ^ byte(crc)
+		ch ^= ch << 4
+		crc = (crc >> 8) ^ (uint16(ch) << 8) ^ (uint16(ch) << 3) ^ (uint16(ch) >> 4)
+	}
+	return [2]byte{byte(crc), byte(crc >> 8)}
+}
+
+func appendCRCA(data []byte) []byte {
+	command := make([]byte, len(data), len(data)+2)
+	copy(command, data)
+	crc := calculateCRCA(data)
+	return append(command, crc[0], crc[1])
+}
+
+func (t *NTAGTag) sendRawType2Command(ctx context.Context, command []byte) ([]byte, error) {
+	data, err := t.device.SendRawCommand(ctx, appendCRCA(command))
+	if selectErr := t.device.InSelect(ctx); selectErr != nil {
+		Debugln("NTAG raw Type 2 command: InSelect failed:", selectErr)
+	}
+	return data, err
+}
+
+func (t *NTAGTag) readRawType2Pages(ctx context.Context, startPage uint8, expectedBytes int) ([]byte, error) {
+	data, err := t.sendRawType2Command(ctx, []byte{ntagCmdRead, startPage})
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < expectedBytes {
+		return nil, fmt.Errorf("invalid raw READ response length %d (expected at least %d)", len(data), expectedBytes)
+	}
+	return data[:expectedBytes], nil
+}

--- a/ntag_raw.go
+++ b/ntag_raw.go
@@ -42,11 +42,10 @@ func appendCRCA(data []byte) []byte {
 }
 
 func (t *NTAGTag) sendRawType2Command(ctx context.Context, command []byte) ([]byte, error) {
-	data, err := t.device.SendRawCommand(ctx, appendCRCA(command))
-	if selectErr := t.device.InSelect(ctx); selectErr != nil {
-		Debugln("NTAG raw Type 2 command: InSelect failed:", selectErr)
-	}
-	return data, err
+	// Raw Type 2 transports preserve the active target themselves. Some acknowledge
+	// InSelect without ever returning its response, which stalls and disrupts the
+	// following exchange.
+	return t.device.SendRawCommand(ctx, appendCRCA(command))
 }
 
 func (t *NTAGTag) readRawType2Pages(ctx context.Context, startPage uint8, expectedBytes int) ([]byte, error) {

--- a/ntag_raw.go
+++ b/ntag_raw.go
@@ -60,6 +60,22 @@ func (t *NTAGTag) sendRawType2Command(ctx context.Context, command []byte) ([]by
 	return t.device.SendRawCommand(ctx, appendCRCA(command))
 }
 
+// sendType2Command selects the raw Type 2 path when required and otherwise uses
+// standardSend. The returned flag reports whether the raw path was selected.
+func (t *NTAGTag) sendType2Command(
+	ctx context.Context,
+	command []byte,
+	standardSend func(context.Context, []byte) ([]byte, error),
+) ([]byte, bool, error) {
+	if t.requiresRawType2Commands() {
+		data, err := t.sendRawType2Command(ctx, command)
+		return data, true, err
+	}
+
+	data, err := standardSend(ctx, command)
+	return data, false, err
+}
+
 // readRawType2Pages reads Type 2 data and removes any bytes beyond the requested
 // payload, including an optional response CRC.
 func (t *NTAGTag) readRawType2Pages(ctx context.Context, startPage uint8, expectedBytes int) ([]byte, error) {

--- a/ntag_raw_test.go
+++ b/ntag_raw_test.go
@@ -115,6 +115,53 @@ func TestNTAGTagRawType2WriteResponses(t *testing.T) {
 	}
 }
 
+func TestNTAGTagRawType2WriteFramingStatusRequiresReadback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		readbackResponse []byte
+		wantError        string
+	}{
+		{
+			name:             "matching readback",
+			readbackResponse: []byte{0x43, 0x00, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:             "mismatched readback",
+			readbackResponse: []byte{0x43, 0x00, 1, 2, 3, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			wantError:        "verification failed",
+		},
+		{
+			name:             "readback failure",
+			readbackResponse: []byte{0x43, 0x01},
+			wantError:        "verification read failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			device, transport := newRawType2Device(t)
+			transport.QueueResponses(cmdInCommunicateThru, []byte{0x43, 0x05}, tt.readbackResponse)
+			tag := NewNTAGTag(device, []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}, 0)
+			tag.tagType = NTAGType213
+
+			err := tag.WriteBlock(context.Background(), 4, []byte{1, 2, 3, 4})
+			if tt.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantError)
+			}
+			assert.Equal(t, [][]byte{
+				{ntagCmdWrite, 0x04, 1, 2, 3, 4, 0x78, 0x57},
+				{ntagCmdRead, 0x04, 0x26, 0xEE},
+			}, transport.commandData(cmdInCommunicateThru))
+			assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+		})
+	}
+}
+
 func TestNTAGTagRawType2SpecialCommands(t *testing.T) {
 	t.Parallel()
 

--- a/ntag_raw_test.go
+++ b/ntag_raw_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+package pn532
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type transportCall struct {
+	data []byte
+	cmd  byte
+}
+
+type rawType2Transport struct {
+	*MockTransport
+	mu    sync.Mutex
+	calls []transportCall
+}
+
+func newRawType2Device(t *testing.T) (*Device, *rawType2Transport) {
+	t.Helper()
+	transport := &rawType2Transport{MockTransport: NewMockTransport()}
+	transport.SelectTarget()
+	device, err := New(transport)
+	require.NoError(t, err)
+	return device, transport
+}
+
+func (t *rawType2Transport) SendCommand(ctx context.Context, cmd byte, data []byte) ([]byte, error) {
+	t.mu.Lock()
+	t.calls = append(t.calls, transportCall{cmd: cmd, data: append([]byte(nil), data...)})
+	t.mu.Unlock()
+	return t.MockTransport.SendCommand(ctx, cmd, data)
+}
+
+func (*rawType2Transport) HasCapability(capability TransportCapability) bool {
+	return capability == CapabilityRequiresRawType2Commands || capability == CapabilityAutoPollNative
+}
+
+func (t *rawType2Transport) commandData(cmd byte) [][]byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var data [][]byte
+	for _, call := range t.calls {
+		if call.cmd == cmd {
+			data = append(data, call.data)
+		}
+	}
+	return data
+}
+
+func TestCalculateCRCA(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, [2]byte{0x26, 0xEE}, calculateCRCA([]byte{ntagCmdRead, 0x04}))
+}
+
+func TestNTAGTagRawType2ReadBlock(t *testing.T) {
+	t.Parallel()
+
+	device, transport := newRawType2Device(t)
+	response := []byte{0x43, 0x00}
+	response = append(response, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08)
+	response = append(response, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10)
+	response = append(response, 0xAA, 0xBB) // Optional card CRC is not part of the returned block.
+	transport.SetResponse(cmdInCommunicateThru, response)
+
+	tag := NewNTAGTag(device, []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}, 0)
+	data, err := tag.ReadBlock(context.Background(), 4)
+
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, data)
+	assert.Equal(t, [][]byte{{ntagCmdRead, 0x04, 0x26, 0xEE}}, transport.commandData(cmdInCommunicateThru))
+	assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+}
+
+func TestNTAGTagRawType2WriteResponses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		response      []byte
+		errorContains string
+	}{
+		{name: "ACK", response: []byte{0x43, 0x00, 0x0A}},
+		{name: "missing ACK", response: []byte{0x43, 0x00}, errorContains: "missing Type 2 ACK"},
+		{name: "NAK", response: []byte{0x43, 0x00, 0x00}, errorContains: "Type 2 NAK"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			device, transport := newRawType2Device(t)
+			transport.SetResponse(cmdInCommunicateThru, tt.response)
+			tag := NewNTAGTag(device, []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}, 0)
+			tag.tagType = NTAGType213
+
+			err := tag.WriteBlock(context.Background(), 4, []byte{1, 2, 3, 4})
+			if tt.errorContains == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errorContains)
+			}
+			assert.Equal(t, [][]byte{{ntagCmdWrite, 0x04, 1, 2, 3, 4, 0x78, 0x57}},
+				transport.commandData(cmdInCommunicateThru))
+			assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+		})
+	}
+}
+
+func TestNTAGTagRawType2SpecialCommands(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FastRead", func(t *testing.T) {
+		t.Parallel()
+		device, transport := newRawType2Device(t)
+		transport.SetResponse(cmdInCommunicateThru, []byte{0x43, 0x00, 1, 2, 3, 4, 0xAA, 0xBB})
+		tag := NewNTAGTag(device, nil, 0)
+
+		data, err := tag.FastRead(context.Background(), 4, 4)
+		require.NoError(t, err)
+		assert.Equal(t, []byte{1, 2, 3, 4}, data)
+		assert.Equal(t, [][]byte{{ntagCmdFastRead, 4, 4, 0x84, 0x71}}, transport.commandData(cmdInCommunicateThru))
+	})
+
+	t.Run("GetVersion", func(t *testing.T) {
+		t.Parallel()
+		device, transport := newRawType2Device(t)
+		versionData := []byte{0x00, 0x04, 0x04, 0x02, 0x01, 0x00, 0x0F, 0x03, 0xAA, 0xBB}
+		transport.SetResponse(cmdInCommunicateThru, append([]byte{0x43, 0x00}, versionData...))
+		tag := NewNTAGTag(device, nil, 0)
+
+		version, err := tag.GetVersion(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, NTAGType213, version.GetNTAGType())
+		assert.Equal(t, [][]byte{{ntagCmdGetVersion, 0xF8, 0x32}}, transport.commandData(cmdInCommunicateThru))
+	})
+
+	t.Run("PwdAuth", func(t *testing.T) {
+		t.Parallel()
+		device, transport := newRawType2Device(t)
+		transport.SetResponse(cmdInCommunicateThru, []byte{0x43, 0x00, 0x12, 0x34, 0xAA, 0xBB})
+		tag := NewNTAGTag(device, nil, 0)
+
+		pack, err := tag.PwdAuth(context.Background(), []byte{1, 2, 3, 4})
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x12, 0x34}, pack)
+		command := []byte{ntagCmdPwdAuth, 1, 2, 3, 4}
+		assert.Equal(t, appendCRCA(command), transport.commandData(cmdInCommunicateThru)[0])
+	})
+}
+
+func TestNTAGTagRawType2ReadNDEF(t *testing.T) {
+	t.Parallel()
+
+	device, transport := newRawType2Device(t)
+	ndefData := []byte{
+		0x03, 0x0D, 0xD1, 0x01, 0x09, 0x54, 0x02, 0x65,
+		0x6E, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x21, 0xFE,
+	}
+	headerResponse := append([]byte{0x43, 0x00}, ndefData...)
+	headerResponse = append(headerResponse, 0xAA, 0xBB)
+	fastReadResponse := append([]byte{0x43, 0x00}, ndefData...)
+	fastReadResponse = append(fastReadResponse, 0xCC, 0xDD)
+	transport.QueueResponses(cmdInCommunicateThru, headerResponse, fastReadResponse)
+
+	tag := NewNTAGTag(device, []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}, 0)
+	tag.tagType = NTAGType213
+	message, err := tag.ReadNDEF(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, message.Records, 1)
+	assert.Equal(t, "Hello!", message.Records[0].Text)
+	assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+}
+
+func TestNTAGTagRawType2WriteNDEFAndVerify(t *testing.T) {
+	t.Parallel()
+
+	device, transport := newRawType2Device(t)
+	message := &NDEFMessage{Records: []NDEFRecord{{Type: NDEFTypeText, Text: "Killer"}}}
+	encoded, err := BuildNDEFMessageEx(message.Records)
+	require.NoError(t, err)
+	blocks := (len(encoded) + ntagBlockSize - 1) / ntagBlockSize
+
+	for range blocks {
+		transport.QueueResponse(cmdInCommunicateThru, []byte{0x43, 0x00, 0x0A})
+	}
+	for i := range blocks {
+		blockData := make([]byte, ntagBlockSize)
+		start := i * ntagBlockSize
+		end := min(start+ntagBlockSize, len(encoded))
+		copy(blockData, encoded[start:end])
+		responseData := make([]byte, 16)
+		copy(responseData, blockData)
+		response := append([]byte{0x43, 0x00}, responseData...)
+		transport.QueueResponse(cmdInCommunicateThru, append(response, 0xAA, 0xBB))
+	}
+
+	tag := NewNTAGTag(device, []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}, 0)
+	tag.tagType = NTAGType213
+	require.NoError(t, tag.WriteNDEF(context.Background(), message))
+	assert.Equal(t, blocks*2, transport.GetCallCount(cmdInCommunicateThru))
+	assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+}

--- a/ntag_raw_test.go
+++ b/ntag_raw_test.go
@@ -78,6 +78,7 @@ func TestNTAGTagRawType2ReadBlock(t *testing.T) {
 	assert.Equal(t, []byte{0x01, 0x02, 0x03, 0x04}, data)
 	assert.Equal(t, [][]byte{{ntagCmdRead, 0x04, 0x26, 0xEE}}, transport.commandData(cmdInCommunicateThru))
 	assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+	assert.Zero(t, transport.GetCallCount(cmdInSelect))
 }
 
 func TestNTAGTagRawType2WriteResponses(t *testing.T) {
@@ -166,9 +167,13 @@ func TestNTAGTagRawType2ReadNDEF(t *testing.T) {
 	}
 	headerResponse := append([]byte{0x43, 0x00}, ndefData...)
 	headerResponse = append(headerResponse, 0xAA, 0xBB)
-	fastReadResponse := append([]byte{0x43, 0x00}, ndefData...)
-	fastReadResponse = append(fastReadResponse, 0xCC, 0xDD)
-	transport.QueueResponses(cmdInCommunicateThru, headerResponse, fastReadResponse)
+	transport.QueueResponse(cmdInCommunicateThru, headerResponse)
+	for offset := 0; offset < len(ndefData); offset += ntagBlockSize {
+		readData := make([]byte, 16)
+		copy(readData, ndefData[offset:])
+		blockResponse := append([]byte{0x43, 0x00}, readData...)
+		transport.QueueResponse(cmdInCommunicateThru, append(blockResponse, 0xCC, 0xDD))
+	}
 
 	tag := NewNTAGTag(device, []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}, 0)
 	tag.tagType = NTAGType213
@@ -177,7 +182,13 @@ func TestNTAGTagRawType2ReadNDEF(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, message.Records, 1)
 	assert.Equal(t, "Hello!", message.Records[0].Text)
+	commands := transport.commandData(cmdInCommunicateThru)
+	require.Len(t, commands, 5)
+	for _, command := range commands {
+		assert.Equal(t, byte(ntagCmdRead), command[0])
+	}
 	assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+	assert.Zero(t, transport.GetCallCount(cmdInSelect))
 }
 
 func TestNTAGTagRawType2WriteNDEFAndVerify(t *testing.T) {

--- a/ntag_raw_test.go
+++ b/ntag_raw_test.go
@@ -5,6 +5,7 @@ package pn532
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -79,6 +80,71 @@ func TestNTAGTagRawType2ReadBlock(t *testing.T) {
 	assert.Equal(t, [][]byte{{ntagCmdRead, 0x04, 0x26, 0xEE}}, transport.commandData(cmdInCommunicateThru))
 	assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
 	assert.Zero(t, transport.GetCallCount(cmdInSelect))
+}
+
+func TestNTAGTagRawType2ReadBlockRetries(t *testing.T) {
+	t.Parallel()
+
+	success := []byte{0x43, 0x00}
+	success = append(success, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08)
+	success = append(success, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10)
+	short := []byte{0x43, 0x00, 0x01, 0x02}
+
+	tests := []struct {
+		name            string
+		responses       [][]byte
+		wantData        []byte
+		wantCalls       int
+		wantError       bool
+		wantReadFailure bool
+	}{
+		{
+			name:      "short response recovers",
+			responses: [][]byte{short, success},
+			wantData:  []byte{0x01, 0x02, 0x03, 0x04},
+			wantCalls: 2,
+		},
+		{
+			name:      "transient RF error recovers",
+			responses: [][]byte{{0x43, 0x02}, success},
+			wantData:  []byte{0x01, 0x02, 0x03, 0x04},
+			wantCalls: 2,
+		},
+		{
+			name:            "short response exhausts retries",
+			responses:       [][]byte{short, short, short},
+			wantCalls:       NTAGBlockReadRetries,
+			wantError:       true,
+			wantReadFailure: true,
+		},
+		{
+			name:      "permanent error is not retried",
+			responses: [][]byte{{0x43, 0x14}},
+			wantCalls: 1,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			device, transport := newRawType2Device(t)
+			transport.QueueResponses(cmdInCommunicateThru, tt.responses...)
+			tag := NewNTAGTag(device, []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}, 0)
+
+			data, err := tag.readBlockWithRetry(context.Background(), 4)
+			if tt.wantError {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantReadFailure, errors.Is(err, ErrTagReadFailed))
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantData, data)
+			}
+			assert.Len(t, transport.commandData(cmdInCommunicateThru), tt.wantCalls)
+			assert.Zero(t, transport.GetCallCount(cmdInDataExchange))
+		})
+	}
 }
 
 func TestNTAGTagRawType2WriteResponses(t *testing.T) {

--- a/tagops/ntag_io_test.go
+++ b/tagops/ntag_io_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:paralleltest // Tests use an intentionally stateful transport simulator.
+package tagops
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ZaparooProject/go-pn532"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCmdInDataExchange    = 0x40
+	testCmdInCommunicateThru = 0x42
+)
+
+type tagopsTransportCall struct {
+	data []byte
+	cmd  byte
+}
+
+type rawTagopsTransport struct {
+	*pn532.MockTransport
+	mu    sync.Mutex
+	calls []tagopsTransportCall
+}
+
+func (t *rawTagopsTransport) SendCommand(ctx context.Context, cmd byte, data []byte) ([]byte, error) {
+	t.mu.Lock()
+	t.calls = append(t.calls, tagopsTransportCall{cmd: cmd, data: append([]byte(nil), data...)})
+	t.mu.Unlock()
+	return t.MockTransport.SendCommand(ctx, cmd, data)
+}
+
+func (*rawTagopsTransport) HasCapability(capability pn532.TransportCapability) bool {
+	return capability == pn532.CapabilityRequiresRawType2Commands ||
+		capability == pn532.CapabilityAutoPollNative
+}
+
+func (t *rawTagopsTransport) commandData(cmd byte) [][]byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var data [][]byte
+	for _, call := range t.calls {
+		if call.cmd == cmd {
+			data = append(data, call.data)
+		}
+	}
+	return data
+}
+
+func newRawTagOperations(t *testing.T) (*TagOperations, *rawTagopsTransport) {
+	t.Helper()
+
+	transport := &rawTagopsTransport{MockTransport: pn532.NewMockTransport()}
+	transport.SelectTarget()
+	device, err := pn532.New(transport)
+	require.NoError(t, err)
+	uid := []byte{0x04, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}
+
+	return &TagOperations{
+		device:       device,
+		tag:          &pn532.DetectedTag{UIDBytes: uid},
+		ntagInstance: pn532.NewNTAGTag(device, uid, 0),
+		tagType:      pn532.TagTypeNTAG,
+		totalPages:   45,
+	}, transport
+}
+
+func TestTagOperationsNTAGReadsUseTagCommandHandling(t *testing.T) {
+	t.Run("single page read", func(t *testing.T) {
+		ops, transport := newRawTagOperations(t)
+		transport.SetResponse(testCmdInCommunicateThru, rawType2Response(
+			[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		))
+
+		data, err := ops.ReadBlocks(context.Background(), 4, 4)
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte{1, 2, 3, 4}, data)
+		assert.Equal(t, byte(0x30), transport.commandData(testCmdInCommunicateThru)[0][0])
+		assert.Zero(t, transport.GetCallCount(testCmdInDataExchange))
+	})
+
+	t.Run("multi-page fast read", func(t *testing.T) {
+		ops, transport := newRawTagOperations(t)
+		transport.SetResponse(testCmdInCommunicateThru, rawType2Response([]byte{1, 2, 3, 4, 5, 6, 7, 8}))
+
+		data, err := ops.ReadBlocks(context.Background(), 4, 5)
+
+		require.NoError(t, err)
+		assert.Equal(t, []byte{1, 2, 3, 4, 5, 6, 7, 8}, data)
+		assert.Equal(t, byte(0x3A), transport.commandData(testCmdInCommunicateThru)[0][0])
+		assert.Zero(t, transport.GetCallCount(testCmdInDataExchange))
+	})
+}
+
+func TestTagOperationsNTAGWritesUseTagCommandHandling(t *testing.T) {
+	ops, transport := newRawTagOperations(t)
+	transport.QueueResponses(testCmdInCommunicateThru,
+		rawType2Response([]byte{0xE1, 0x10, 0x12, 0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
+		rawType2Response(make([]byte, 16)),
+		rawType2Response([]byte{0x0A}),
+	)
+
+	err := ops.WriteBlocks(context.Background(), 4, []byte{1, 2, 3, 4})
+
+	require.NoError(t, err)
+	commands := transport.commandData(testCmdInCommunicateThru)
+	require.Len(t, commands, 3)
+	assert.Equal(t, byte(0xA2), commands[2][0])
+	assert.Zero(t, transport.GetCallCount(testCmdInDataExchange))
+}
+
+func rawType2Response(payload []byte) []byte {
+	return append([]byte{0x43, 0x00}, payload...)
+}

--- a/tagops/reader.go
+++ b/tagops/reader.go
@@ -158,14 +158,7 @@ func (t *TagOperations) tryFastRead(ctx context.Context, currentPage, chunkEnd b
 		return nil, 0
 	}
 
-	cmd := []byte{0x3A, currentPage, chunkEnd}
-	data, err := t.device.SendRawCommand(ctx, cmd)
-
-	// Re-select target after SendRawCommand to restore PN532 internal state
-	// SendRawCommand uses InCommunicateThru which doesn't maintain target selection
-	if selectErr := t.device.InSelect(ctx); selectErr != nil {
-		pn532.Debugln("tagops tryFastRead: InSelect failed (non-fatal):", selectErr)
-	}
+	data, err := t.ntagInstance.FastRead(ctx, currentPage, chunkEnd)
 
 	if err == nil {
 		return data, chunkEnd + 1
@@ -181,7 +174,7 @@ func (t *TagOperations) readPagesIndividually(
 		if err := ctx.Err(); err != nil {
 			return nil, 0, err
 		}
-		pageData, err := t.device.SendDataExchange(ctx, []byte{0x30, page})
+		pageData, err := t.ntagInstance.ReadBlock(ctx, page)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to read page %d: %w", page, err)
 		}

--- a/tagops/reader.go
+++ b/tagops/reader.go
@@ -153,6 +153,8 @@ func (t *TagOperations) readPageChunk(
 	return t.readPagesIndividually(ctx, currentPage, chunkEnd)
 }
 
+// tryFastRead reads a page range with the NTAG fast-read command and returns
+// the next page when the command succeeds.
 func (t *TagOperations) tryFastRead(ctx context.Context, currentPage, chunkEnd byte) (data []byte, nextPage byte) {
 	if chunkEnd <= currentPage {
 		return nil, 0
@@ -167,6 +169,7 @@ func (t *TagOperations) tryFastRead(ctx context.Context, currentPage, chunkEnd b
 	return nil, 0
 }
 
+// readPagesIndividually reads a page range with standard NTAG read commands.
 func (t *TagOperations) readPagesIndividually(
 	ctx context.Context, currentPage, chunkEnd byte,
 ) (result []byte, nextPage byte, err error) {

--- a/tagops/writer.go
+++ b/tagops/writer.go
@@ -107,10 +107,7 @@ func (t *TagOperations) writeNTAGBlocks(ctx context.Context, startBlock byte, da
 		}
 		copy(pageData, data[dataStart:dataEnd])
 
-		// Write command: 0xA2 page data[4]
-		cmd := append([]byte{0xA2, page}, pageData...)
-		_, err := t.device.SendDataExchange(ctx, cmd)
-		if err != nil {
+		if err := t.ntagInstance.WriteBlock(ctx, page, pageData); err != nil {
 			return fmt.Errorf("failed to write page %d: %w", page, err)
 		}
 	}

--- a/transport.go
+++ b/transport.go
@@ -71,6 +71,10 @@ const (
 	// CapabilityUART indicates the transport uses UART communication
 	// UART transport is prone to PN532 firmware lockups with large InCommunicateThru payloads
 	CapabilityUART TransportCapability = "uart"
+
+	// CapabilityRequiresRawType2Commands indicates NFC Forum Type 2 commands
+	// must use InCommunicateThru with a software-generated CRC-A.
+	CapabilityRequiresRawType2Commands TransportCapability = "requires_raw_type2_commands"
 )
 
 // TransportCapabilityChecker defines an interface for querying transport capabilities

--- a/transport/uart/profile.go
+++ b/transport/uart/profile.go
@@ -28,17 +28,24 @@ const (
 	pn532KillerProduct = "PN532Killer-UART"
 )
 
+// deviceProfile identifies transport behavior selected from serial device metadata.
 type deviceProfile uint8
 
 const (
+	// profileGeneric preserves standard PN532 UART behavior.
 	profileGeneric deviceProfile = iota
+	// profilePN532Killer enables behavior required by compatible PN532Killer firmware.
 	profilePN532Killer
 )
 
+// getDetailedPortsList provides a stable test seam across supported serial
+// dependency versions.
 var getDetailedPortsList = func() ([]*enumerator.PortDetails, error) {
 	return enumerator.GetDetailedPortsList()
 }
 
+// resolveDeviceProfile selects a device profile only when the port's strict USB
+// identity matches a supported profile.
 func resolveDeviceProfile(portName string) deviceProfile {
 	ports, err := getDetailedPortsList()
 	if err != nil {
@@ -60,6 +67,8 @@ func resolveDeviceProfile(portName string) deviceProfile {
 	return profileGeneric
 }
 
+// canonicalPortName resolves serial device symlinks when possible and cleans the
+// resulting path for comparison.
 func canonicalPortName(portName string) string {
 	resolved, err := filepath.EvalSymlinks(portName)
 	if err == nil {

--- a/transport/uart/profile.go
+++ b/transport/uart/profile.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uart
+
+import (
+	"path/filepath"
+	"strings"
+
+	"go.bug.st/serial/enumerator"
+)
+
+const (
+	pn532KillerVID     = "1A86"
+	pn532KillerPID     = "55D3"
+	pn532KillerProduct = "PN532Killer-UART"
+)
+
+type deviceProfile uint8
+
+const (
+	profileGeneric deviceProfile = iota
+	profilePN532Killer
+)
+
+var getDetailedPortsList = enumerator.GetDetailedPortsList
+
+func resolveDeviceProfile(portName string) deviceProfile {
+	ports, err := getDetailedPortsList()
+	if err != nil {
+		return profileGeneric
+	}
+
+	wantedName := canonicalPortName(portName)
+	for _, port := range ports {
+		if port == nil || !strings.EqualFold(canonicalPortName(port.Name), wantedName) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(port.VID), pn532KillerVID) &&
+			strings.EqualFold(strings.TrimSpace(port.PID), pn532KillerPID) &&
+			strings.EqualFold(strings.TrimSpace(port.Product), pn532KillerProduct) {
+			return profilePN532Killer
+		}
+	}
+
+	return profileGeneric
+}
+
+func canonicalPortName(portName string) string {
+	resolved, err := filepath.EvalSymlinks(portName)
+	if err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(portName)
+}

--- a/transport/uart/profile.go
+++ b/transport/uart/profile.go
@@ -35,7 +35,9 @@ const (
 	profilePN532Killer
 )
 
-var getDetailedPortsList = enumerator.GetDetailedPortsList
+var getDetailedPortsList = func() ([]*enumerator.PortDetails, error) {
+	return enumerator.GetDetailedPortsList()
+}
 
 func resolveDeviceProfile(portName string) deviceProfile {
 	ports, err := getDetailedPortsList()

--- a/transport/uart/profile_test.go
+++ b/transport/uart/profile_test.go
@@ -5,6 +5,8 @@
 package uart
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"testing"
 
@@ -113,4 +115,49 @@ func TestPN532KillerProfilePersistsAcrossReconnect(t *testing.T) {
 		assert.False(t, mode.InitialStatusBits.RTS)
 	}
 	assert.True(t, transport.HasCapability(pn532.CapabilityRequiresRawType2Commands))
+}
+
+type recordingSerialPort struct {
+	serial.Port
+	writes [][]byte
+}
+
+func (p *recordingSerialPort) Write(data []byte) (int, error) {
+	p.writes = append(p.writes, append([]byte(nil), data...))
+	return p.Port.Write(data)
+}
+
+func TestResponseACKProfileBehavior(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     deviceProfile
+		wantHostACK bool
+	}{
+		{name: "generic UART sends response ACK", profile: profileGeneric, wantHostACK: true},
+		{name: "PN532Killer omits response ACK", profile: profilePN532Killer, wantHostACK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := &recordingSerialPort{Port: NewMockSerialPort(virt.NewVirtualPN532())}
+			transport := &Transport{
+				port:           port,
+				portName:       "mock://profile-test",
+				currentTimeout: getReadTimeout(),
+				profile:        tt.profile,
+			}
+
+			_, err := transport.SendCommand(context.Background(), 0x02, nil)
+			require.NoError(t, err)
+
+			hasHostACK := false
+			for _, write := range port.writes {
+				if bytes.Equal(write, ackFrame) {
+					hasHostACK = true
+					break
+				}
+			}
+			assert.Equal(t, tt.wantHostACK, hasHostACK)
+		})
+	}
 }

--- a/transport/uart/profile_test.go
+++ b/transport/uart/profile_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The Zaparoo Project Contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:paralleltest // Tests replace package-level serial enumeration/open functions.
+package uart
+
+import (
+	"errors"
+	"testing"
+
+	pn532 "github.com/ZaparooProject/go-pn532"
+	virt "github.com/ZaparooProject/go-pn532/internal/testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.bug.st/serial"
+	"go.bug.st/serial/enumerator"
+)
+
+func TestResolveDeviceProfile(t *testing.T) {
+	original := getDetailedPortsList
+	t.Cleanup(func() { getDetailedPortsList = original })
+
+	tests := []struct {
+		name    string
+		port    *enumerator.PortDetails
+		listErr error
+		want    deviceProfile
+	}{
+		{
+			name: "exact PN532Killer metadata",
+			port: &enumerator.PortDetails{
+				Name: "/dev/ttyACM0", VID: "1a86", PID: "55d3", Product: "PN532Killer-UART",
+			},
+			want: profilePN532Killer,
+		},
+		{
+			name: "missing product",
+			port: &enumerator.PortDetails{Name: "/dev/ttyACM0", VID: "1A86", PID: "55D3"},
+			want: profileGeneric,
+		},
+		{
+			name: "wrong product",
+			port: &enumerator.PortDetails{
+				Name: "/dev/ttyACM0", VID: "1A86", PID: "55D3", Product: "USB Serial",
+			},
+			want: profileGeneric,
+		},
+		{
+			name: "wrong VID PID",
+			port: &enumerator.PortDetails{
+				Name: "/dev/ttyACM0", VID: "1A86", PID: "7523", Product: "PN532Killer-UART",
+			},
+			want: profileGeneric,
+		},
+		{
+			name:    "enumeration failure",
+			listErr: errors.New("enumeration failed"),
+			want:    profileGeneric,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getDetailedPortsList = func() ([]*enumerator.PortDetails, error) {
+				if tt.port == nil {
+					return nil, tt.listErr
+				}
+				return []*enumerator.PortDetails{tt.port}, tt.listErr
+			}
+
+			assert.Equal(t, tt.want, resolveDeviceProfile("/dev/ttyACM0"))
+		})
+	}
+}
+
+func TestSerialModeProfileSettings(t *testing.T) {
+	genericMode := serialMode(profileGeneric)
+	assert.Nil(t, genericMode.InitialStatusBits)
+
+	killerMode := serialMode(profilePN532Killer)
+	require.NotNil(t, killerMode.InitialStatusBits)
+	assert.False(t, killerMode.InitialStatusBits.DTR)
+	assert.False(t, killerMode.InitialStatusBits.RTS)
+}
+
+func TestPN532KillerProfilePersistsAcrossReconnect(t *testing.T) {
+	originalEnumerate := getDetailedPortsList
+	originalOpen := openSerialPort
+	t.Cleanup(func() {
+		getDetailedPortsList = originalEnumerate
+		openSerialPort = originalOpen
+	})
+
+	getDetailedPortsList = func() ([]*enumerator.PortDetails, error) {
+		return []*enumerator.PortDetails{{
+			Name: "/dev/ttyACM0", VID: "1A86", PID: "55D3", Product: "PN532Killer-UART",
+		}}, nil
+	}
+
+	var modes []*serial.Mode
+	openSerialPort = func(_ string, mode *serial.Mode) (serial.Port, error) {
+		modes = append(modes, mode)
+		return NewMockSerialPort(virt.NewVirtualPN532()), nil
+	}
+
+	transport, err := New("/dev/ttyACM0")
+	require.NoError(t, err)
+	require.NoError(t, transport.Reconnect())
+	require.Len(t, modes, 2)
+	for _, mode := range modes {
+		require.NotNil(t, mode.InitialStatusBits)
+		assert.False(t, mode.InitialStatusBits.DTR)
+		assert.False(t, mode.InitialStatusBits.RTS)
+	}
+	assert.True(t, transport.HasCapability(pn532.CapabilityRequiresRawType2Commands))
+}

--- a/transport/uart/uart.go
+++ b/transport/uart/uart.go
@@ -205,8 +205,10 @@ func (t *Transport) handleNormalResponse(ctx context.Context, ackData []byte) ([
 		return nil, t.currentTrace.WrapError(err)
 	}
 
-	if err := t.sendAck(ctx); err != nil {
-		return nil, t.currentTrace.WrapError(err)
+	if t.profile != profilePN532Killer {
+		if err := t.sendAck(ctx); err != nil {
+			return nil, t.currentTrace.WrapError(err)
+		}
 	}
 
 	t.connectionEstablished = true

--- a/transport/uart/uart.go
+++ b/transport/uart/uart.go
@@ -46,8 +46,9 @@ const (
 )
 
 var (
-	ackFrame  = []byte{0x00, 0x00, 0xFF, 0x00, 0xFF, 0x00}
-	nackFrame = []byte{0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00}
+	ackFrame       = []byte{0x00, 0x00, 0xFF, 0x00, 0xFF, 0x00}
+	nackFrame      = []byte{0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00}
+	openSerialPort = serial.Open
 )
 
 // Transport implements the pn532.Transport interface for UART communication.
@@ -61,6 +62,7 @@ type Transport struct {
 	lastCommand           byte
 	connectionEstablished bool
 	disconnected          bool // Set when device-gone is detected during I/O
+	profile               deviceProfile
 }
 
 // isWindows returns true if running on Windows
@@ -105,14 +107,37 @@ func windowsPostWriteDelay() {
 
 // New creates a new UART transport.
 func New(portName string) (*Transport, error) {
-	port, err := serial.Open(portName, &serial.Mode{
+	profile := resolveDeviceProfile(portName)
+	port, timeout, err := openPort(portName, profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open UART port %s: %w", portName, err)
+	}
+
+	return &Transport{
+		port:           port,
+		portName:       portName,
+		currentTimeout: timeout, // Initialize with default read timeout
+		profile:        profile,
+	}, nil
+}
+
+func serialMode(profile deviceProfile) *serial.Mode {
+	mode := &serial.Mode{
 		BaudRate: 115200,
 		DataBits: 8,
 		Parity:   serial.NoParity,
 		StopBits: serial.OneStopBit,
-	})
+	}
+	if profile == profilePN532Killer {
+		mode.InitialStatusBits = &serial.ModemOutputBits{DTR: false, RTS: false}
+	}
+	return mode
+}
+
+func openPort(portName string, profile deviceProfile) (serial.Port, time.Duration, error) {
+	port, err := openSerialPort(portName, serialMode(profile))
 	if err != nil {
-		return nil, fmt.Errorf("failed to open UART port %s: %w", portName, err)
+		return nil, 0, err
 	}
 
 	// Set unified read timeout - originally 50ms on Linux/Mac and 100ms on Windows,
@@ -120,14 +145,9 @@ func New(portName string) (*Transport, error) {
 	timeout := getReadTimeout()
 	if err := port.SetReadTimeout(timeout); err != nil {
 		_ = port.Close()
-		return nil, fmt.Errorf("failed to set UART read timeout: %w", err)
+		return nil, 0, fmt.Errorf("failed to set UART read timeout: %w", err)
 	}
-
-	return &Transport{
-		port:           port,
-		portName:       portName,
-		currentTimeout: timeout, // Initialize with default read timeout
-	}, nil
+	return port, timeout, nil
 }
 
 // sleepCtx performs a context-aware sleep. Returns ctx.Err() if context is cancelled.
@@ -355,21 +375,9 @@ func (t *Transport) Reconnect() error {
 	time.Sleep(100 * time.Millisecond)
 
 	// Reopen with same settings
-	port, err := serial.Open(t.portName, &serial.Mode{
-		BaudRate: 115200,
-		DataBits: 8,
-		Parity:   serial.NoParity,
-		StopBits: serial.OneStopBit,
-	})
+	port, timeout, err := openPort(t.portName, t.profile)
 	if err != nil {
 		return fmt.Errorf("reconnect failed: %w", err)
-	}
-
-	// Set read timeout
-	timeout := getReadTimeout()
-	if err := port.SetReadTimeout(timeout); err != nil {
-		_ = port.Close()
-		return fmt.Errorf("reconnect set timeout failed: %w", err)
 	}
 
 	t.port = port
@@ -1235,7 +1243,7 @@ func (t *Transport) receiveSpecialDiagnoseByte(ctx context.Context, _ byte) ([]b
 
 // HasCapability implements the TransportCapabilityChecker interface
 // UART transport supports native InAutoPoll for reduced CPU usage
-func (*Transport) HasCapability(capability pn532.TransportCapability) bool {
+func (t *Transport) HasCapability(capability pn532.TransportCapability) bool {
 	switch capability {
 	case pn532.CapabilityAutoPollNative:
 		// UART supports native InAutoPoll command
@@ -1246,6 +1254,8 @@ func (*Transport) HasCapability(capability pn532.TransportCapability) bool {
 	case pn532.CapabilityUART:
 		// This is the UART transport
 		return true
+	case pn532.CapabilityRequiresRawType2Commands:
+		return t.profile == profilePN532Killer
 	default:
 		return false
 	}

--- a/transport/uart/uart.go
+++ b/transport/uart/uart.go
@@ -121,6 +121,7 @@ func New(portName string) (*Transport, error) {
 	}, nil
 }
 
+// serialMode builds the UART mode for the selected device profile.
 func serialMode(profile deviceProfile) *serial.Mode {
 	mode := &serial.Mode{
 		BaudRate: 115200,
@@ -134,6 +135,7 @@ func serialMode(profile deviceProfile) *serial.Mode {
 	return mode
 }
 
+// openPort opens a serial device and applies the shared UART read timeout.
 func openPort(portName string, profile deviceProfile) (serial.Port, time.Duration, error) {
 	port, err := openSerialPort(portName, serialMode(profile))
 	if err != nil {


### PR DESCRIPTION
## Summary

Add PN532Killer compatibility through the existing UART transport and NTAG/Type 2 APIs. Applications continue using the standard UART constructor and do not need a separate driver or configuration option.

This supports the reader integration required by the companion Zaparoo Core PR https://github.com/ZaparooProject/zaparoo-core/pull/1158.

## Background

PN532Killer exposes a PN532-compatible UART interface, but the tested firmware differs from a standard PN532 in several areas:

- DTR and RTS must remain deasserted.
- It does not tolerate the host ACK normally sent after a PN532 response.
- Type 2 commands must use `InCommunicateThru` with software-generated CRC-A bytes.
- `InSelect` may be acknowledged without returning a response.
- `FAST_READ` reports framing status `0x05`, while standard Type 2 `READ` works.
- A successful Type 2 `WRITE` may also report framing status `0x05` because the tag ACK is four bits.

These differences previously prevented initialization or reliable NTAG access.

## Changes

- Add `1A86:55D3` as a likely PN532 UART detection candidate while retaining safe probing.
- Select the PN532Killer profile only when all normalized USB metadata matches:
  - VID `1A86`
  - PID `55D3`
  - Product `PN532Killer-UART`
- Resolve serial-device symlinks before matching metadata.
- Open matching readers with DTR and RTS deasserted.
- Preserve the selected profile and serial settings across reconnects.
- Omit the response ACK only for the PN532Killer profile.
- Add a transport capability for readers requiring raw Type 2 commands.
- Generate ISO/IEC 14443-A CRC bytes and route applicable NTAG commands through `InCommunicateThru`.
- Route page reads, writes, NDEF access, `FAST_READ`, `GET_VERSION`, and `PWD_AUTH` through the appropriate transport path.
- Fall back to standard Type 2 `READ` operations when `FAST_READ` is unavailable.
- Validate normal Type 2 write ACKs and verify page contents after the observed ambiguous framing status.
- Centralize NTAG operations used by `tagops` through `NTAGTag`.
- Document supported operations, strict identification, limitations, and troubleshooting.

The generic UART and standard PN532 command paths remain unchanged when the strict metadata match is not satisfied.

## Scope

Supported:

- Reader initialization and automatic detection
- NTAG/Type 2 UID detection
- Page and NDEF reads
- Page and NDEF writes
- NTAG version and password-authentication commands
- Reconnect behavior

Not included in the compatibility claim:

- MIFARE operations
- Card emulation
- Traffic sniffing
- ISO15693
- PN532Killer-specific extended features

## Validation

- `GOWORK=off go test ./...`
- Added focused tests for:
  - Strict USB profile selection and generic fallback
  - Serial status bits, response ACK behavior, and reconnects
  - Detection candidacy and metadata retention
  - CRC-A generation
  - Raw Type 2 reads, writes, ACK/NAK handling, and framing-status verification
  - `FAST_READ`, `GET_VERSION`, and `PWD_AUTH`
  - NDEF read and write verification
  - Centralized `tagops` NTAG handling
- Completed UID and NDEF read/write testing with a PN532Killer.
- Repeated read/write testing with a standard PN532 to confirm the existing UART path remains functional.
- Validated the library in a locally linked Zaparoo Core build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added automatic support for PN532Killer USB UART readers via improved device detection.
  * Improved NTAG compatibility for “raw Type 2” transports, including more reliable block/NDEF reads, writes, authentication, and version checks.

* **Bug Fixes**
  * Strengthened raw Type 2 write handling with ACK/NAK validation and readback verification to reduce false successes.

* **Documentation**
  * Added developer documentation covering PN532Killer interoperability, supported operations, limitations, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->